### PR TITLE
chore: use deploy/action.yml in ci.yml

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -2,15 +2,17 @@ name: Deploy
 
 inputs:
   env_aws_secret_name:
-    required: true
+    required: false
     type: string
+    default: ''
   dir:
     required: false
     type: string
     default: "."
   script_path:
-    required: true
+    required: false
     type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -42,6 +44,7 @@ runs:
         uv run npm install
 
     - name: Get relevant environment configuration from aws secrets
+      if: inputs.env_aws_secret_name != ''
       shell: bash
       working-directory: ${{ inputs.dir }}
       env:
@@ -53,8 +56,30 @@ runs:
         python ${{ inputs.script_path }} --secret-id ${{ inputs.env_aws_secret_name }}
         fi
 
+    - name: CDK Synth
+      shell: bash
+      working-directory: ${{ inputs.dir }}
+      run: uv run --only-group deployment npm run cdk -- synth
+
+    - name: Check Asset Sizes
+      shell: bash
+      working-directory: ${{ inputs.dir }}
+      run: |
+        MAX_SIZE_BYTES=262144000  # 262 MB in bytes
+        for dir in cdk.out/asset.*; do
+          if [ -d "$dir" ]; then
+            size=$(du -sb "$dir" | cut -f1)
+            if [ "$size" -gt $MAX_SIZE_BYTES ]; then
+              echo "Directory $dir exceeds 262 MB with size $size bytes (max: $MAX_SIZE_BYTES bytes)."
+              exit 1
+            fi
+            echo "Asset directory $dir size: $size bytes"
+          fi
+        done
+        echo "All asset directories are within size limits."
+
     - name: Deploy
-      id: deploy_titiler_xarray_stack
+      id: deploy_titiler_multidim_stack
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -13,6 +13,10 @@ inputs:
     required: false
     type: string
     default: ''
+  skip_deploy:
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -79,6 +83,7 @@ runs:
         echo "All asset directories are within size limits."
 
     - name: Deploy
+      if: ${{ !inputs.skip_deploy }}
       id: deploy_titiler_multidim_stack
       shell: bash
       working-directory: ${{ inputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,41 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
+  cdk-checks:
+    needs: [tests]
+    runs-on: ubuntu-latest
+    environment: dev
+    if: github.event_name == 'pull_request'
+    env:
+      UV_PYTHON: 3.12
+      TITILER_MULTIDIM_PYTHONWARNINGS: ignore
+      TITILER_MULTIDIM_DEBUG: true
+      STACK_ALARM_EMAIL: ${{ secrets.ALARM_EMAIL }}
+      STACK_CDK_DEFAULT_ACCOUNT: ${{ vars.STACK_CDK_DEFAULT_ACCOUNT }}
+      STACK_CDK_DEFAULT_REGION: ${{ vars.STACK_CDK_DEFAULT_REGION }}
+      STACK_READER_ROLE_ARN: ${{ vars.STACK_READER_ROLE_ARN }}
+      STACK_STAGE: ${{ vars.STACK_STAGE }}
+      STACK_VPC_ID: ${{ vars.STACK_VPD_ID }}
+  
+    defaults:
+      run:
+        working-directory: infrastructure/aws
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: github-actions-pr
+          aws-region: ${{ vars.STACK_CDK_DEFAULT_REGION }}
+
+      - uses: ./.github/actions/cdk-deploy
+        with:
+          dir: 'infrastructure/aws'
+          skip_deploy: true
+
   deploy-development:
     needs: [tests]
     runs-on: ubuntu-latest
@@ -87,6 +122,7 @@ jobs:
       - uses: ./.github/actions/cdk-deploy
         with:
           dir: 'infrastructure/aws'
+          skip_deploy: false
 
   deploy-production:
     needs: [tests]
@@ -121,3 +157,4 @@ jobs:
       - uses: ./.github/actions/cdk-deploy
         with:
           dir: 'infrastructure/aws'
+          skip_deploy: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: Test and Deploy
 
-# Triggers on pushes to main, dev and tags.
 on:
   workflow_dispatch:
   push:
@@ -10,19 +9,19 @@ on:
     tags:
     - 'v*'
     paths:
-      # Only run test and docker publish if some code have changed
       - 'pyproject.toml'
       - 'infrastructure/aws/**'
       - 'titiler/**'
       - '.pre-commit-config.yaml'
-  # Run tests on pull requests.
   pull_request:
+
 env:
   LATEST_PY_VERSION: '3.12'
 
 permissions:
-  id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
+  id-token: write
+  contents: read
+
 
 jobs:
   tests:
@@ -55,13 +54,21 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
-  deploy:
+  deploy-development:
     needs: [tests]
     runs-on: ubuntu-latest
+    environment: dev
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
     env:
       UV_PYTHON: 3.12
-      STACK_READER_ROLE_ARN: ${{ secrets.READER_ROLE_ARN }}
+      TITILER_MULTIDIM_PYTHONWARNINGS: ignore
+      TITILER_MULTIDIM_DEBUG: true
       STACK_ALARM_EMAIL: ${{ secrets.ALARM_EMAIL }}
+      STACK_CDK_DEFAULT_ACCOUNT: ${{ vars.STACK_CDK_DEFAULT_ACCOUNT }}
+      STACK_CDK_DEFAULT_REGION: ${{ vars.STACK_CDK_DEFAULT_REGION }}
+      STACK_READER_ROLE_ARN: ${{ vars.STACK_READER_ROLE_ARN }}
+      STACK_STAGE: ${{ vars.STACK_STAGE }}
+      STACK_VPC_ID: ${{ vars.STACK_VPD_ID }}
   
     defaults:
       run:
@@ -73,60 +80,44 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::444055461661:role/github-actions-role-eodc
-          role-session-name: samplerolesession
-          aws-region: us-west-2
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: github-actions-dev
+          aws-region: ${{ vars.STACK_CDK_DEFAULT_REGION }}
 
-      - name: Install node and related deps
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/cdk-deploy
         with:
-          node-version: 20
+          dir: 'infrastructure/aws'
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
+  deploy-production:
+    needs: [tests]
+    runs-on: ubuntu-latest
+    environment: production
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      UV_PYTHON: 3.12
+      TITILER_MULTIDIM_PYTHONWARNINGS: ignore
+      TITILER_MULTIDIM_DEBUG: true
+      STACK_ALARM_EMAIL: ${{ secrets.ALARM_EMAIL }}
+      STACK_CDK_DEFAULT_ACCOUNT: ${{ vars.STACK_CDK_DEFAULT_ACCOUNT }}
+      STACK_CDK_DEFAULT_REGION: ${{ vars.STACK_CDK_DEFAULT_REGION }}
+      STACK_READER_ROLE_ARN: ${{ vars.STACK_READER_ROLE_ARN }}
+      STACK_STAGE: ${{ vars.STACK_STAGE }}
+      STACK_VPC_ID: ${{ vars.STACK_VPD_ID }}
+  
+    defaults:
+      run:
+        working-directory: infrastructure/aws
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          version: "0.5.*" 
-          enable-cache: true
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: github-actions-dev
+          aws-region: ${{ vars.STACK_CDK_DEFAULT_REGION }}
 
-      - name: Install dependencies
-        run: |
-          uv sync --only-group deployment
-          uv run npm install
-
-      - name: CDK Synth
-        run: uv run --only-group deployment npm run cdk -- synth
-
-      - name: Check Asset Sizes
-        run: |
-          MAX_SIZE_BYTES=262144000  # 262 MB in bytes
-          for dir in cdk.out/asset.*; do
-            if [ -d "$dir" ]; then
-              size=$(du -sb "$dir" | cut -f1)
-              if [ "$size" -gt $MAX_SIZE_BYTES ]; then
-                echo "Directory $dir exceeds 262 MB with size $size bytes (max: $MAX_SIZE_BYTES bytes)."
-                exit 1 # Exit with failure if any asset directory is too large
-              fi
-              echo "Asset directory $dir size: $size bytes"
-            fi
-          done
-          echo "All asset directories are within size limits."
-      
-      # Build and deploy to the development environment whenever there is a push to main or dev
-      - name: Build & Deploy Development
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-        run: uv run npm run cdk -- deploy titiler-multidim-development --require-approval never
-        env:
-          TITILER_MULTIDIM_PYTHONWARNINGS: ignore
-          TITILER_MULTIDIM_DEBUG: True
-          STACK_STAGE: development
-          STACK_NAME: titiler-multidim
-          
-      # Build and deploy to production deployment whenever there a new tag is pushed
-      - name: Build & Deploy Production
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: uv run npm run cdk -- deploy titiler-multidim-production --require-approval never
-        env:
-          TITILER_MULTIDIM_PYTHONWARNINGS: ignore
-          TITILER_MULTIDIM_DEBUG: True
-          STACK_STAGE: production
-          STACK_NAME: titiler-multidim
+      - uses: ./.github/actions/cdk-deploy
+        with:
+          dir: 'infrastructure/aws'


### PR DESCRIPTION
Update `ci.yml` to re-use `deploy/action.yml`, read variables from GitHub Actions environment. 
Resolves #79 
