### PR TITLE
add custom host + root_path config

### DIFF
--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -140,6 +140,7 @@ class LambdaStack(Stack):
             environment={
                 **DEFAULT_ENV,
                 **environment,
+                "TITILER_MULTIDIM_ROOT_PATH": app_settings.root_path,
                 "TITILER_MULTIDIM_CACHE_HOST": redis_cluster.attr_redis_endpoint_address,
             },
             log_retention=logs.RetentionDays.ONE_WEEK,
@@ -156,7 +157,14 @@ class LambdaStack(Stack):
             self,
             f"{id}-endpoint",
             default_integration=HttpLambdaIntegration(
-                f"{id}-integration", lambda_function
+                f"{id}-integration",
+                lambda_function,
+                parameter_mapping=apigw.ParameterMapping().overwrite_header(
+                    "host",
+                    apigw.MappingValue(stack_settings.veda_custom_host),
+                )
+                if stack_settings.veda_custom_host
+                else None,
             ),
         )
 

--- a/infrastructure/aws/cdk/config.py
+++ b/infrastructure/aws/cdk/config.py
@@ -43,6 +43,10 @@ class StackSettings(BaseSettings):
         None,
         description="When deploying from a local machine the AWS region id is required to deploy to an existing VPC",
     )
+    veda_custom_host: Optional[str] = Field(
+        None,
+        description="Complete url of custom host including subdomain. When provided, override host in api integration",
+    )
 
     def cdk_env(self) -> dict:
         """Load a cdk environment dict for stack"""
@@ -86,6 +90,11 @@ class AppSettings(BaseSettings):
     # Default: - No specific limit - account limit.
     max_concurrent: Optional[int] = None
     alarm_email: Optional[str] = ""
+
+    root_path: str = Field(
+        "",
+        description="Optional root path for all api endpoints",
+    )
 
     class Config:
         """model config"""


### PR DESCRIPTION
Just a few small changes required to enable the `{custom_host}/{root_path}` capability so we can add a route path for this app in a CloudFront distribution. This is how the rest of the VEDA backend APIs are set up so I just followed that pattern!

e.g. raster api `root_path`: https://github.com/NASA-IMPACT/veda-backend/blob/28424ff69fb32cfc620cb8ebe35273f883b45be3/raster_api/infrastructure/config.py#L74-L77

and `veda_custom_host`: https://github.com/NASA-IMPACT/veda-backend/blob/28424ff69fb32cfc620cb8ebe35273f883b45be3/config.py#L87-L90

