### PR TITLE
Parametrize test functions

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pytest
 
 from helpers import find_string_in_stream
 
@@ -9,7 +10,9 @@ test_netcdf_store = os.path.join(DATA_DIR, "testfile.nc")
 test_unconsolidated_store = os.path.join(DATA_DIR, "unconsolidated.zarr")
 test_pyramid_store = os.path.join(DATA_DIR, "pyramid.zarr")
 
-test_zarr_store_params = {
+store_params = {}
+
+store_params['zarr_store'] = {
     "params": {
         "url": test_zarr_store,
         "variable": "CDD0",
@@ -19,7 +22,7 @@ test_zarr_store_params = {
     "variables": ["CDD0", "DISPH", "FROST_DAYS", "GWETPROF"],
 }
 
-test_netcdf_store_params = {
+store_params['netcdf_store'] = {
     "params": {
         "url": test_netcdf_store,
         "variable": "data",
@@ -28,7 +31,7 @@ test_netcdf_store_params = {
     },
     "variables": ["data"],
 }
-test_unconsolidated_store_params = {
+store_params['unconsolidated_store'] = {
     "params": {
         "url": test_unconsolidated_store,
         "variable": "var1",
@@ -37,7 +40,7 @@ test_unconsolidated_store_params = {
     },
     "variables": ["var1", "var2"],
 }
-test_pyramid_store_params = {
+store_params['pyramid_store'] = {
     "params": {
         "url": test_pyramid_store,
         "variable": "value",
@@ -59,21 +62,9 @@ def get_variables_test(app, ds_params):
     assert timings[0].startswith("total;dur=")
     assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
 
-
-def test_get_variables_test(app):
-    return get_variables_test(app, test_zarr_store_params)
-
-
-def test_get_variables_netcdf(app):
-    return get_variables_test(app, test_netcdf_store_params)
-
-
-def test_get_variables_unconsolidated(app):
-    return get_variables_test(app, test_unconsolidated_store_params)
-
-
-def test_get_variables_pyramid(app):
-    return get_variables_test(app, test_pyramid_store_params)
+@pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
+def test_get_variables(store_params, app):
+    return get_variables_test(app, store_params)
 
 
 def get_info_test(app, ds_params):
@@ -89,21 +80,9 @@ def get_info_test(app, ds_params):
     ) as f:
         assert response.json() == json.load(f)
 
-
-def test_get_info_test(app):
-    return get_info_test(app, test_zarr_store_params)
-
-
-def test_get_info_netcdf(app):
-    return get_info_test(app, test_netcdf_store_params)
-
-
-def test_get_info_unconsolidated(app):
-    return get_info_test(app, test_unconsolidated_store_params)
-
-
-def test_get_info_pyramid(app):
-    return get_info_test(app, test_pyramid_store_params)
+@pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
+def test_get_info(store_params, app):
+    return get_info_test(app, store_params)
 
 
 def get_tilejson_test(app, ds_params):
@@ -120,22 +99,9 @@ def get_tilejson_test(app, ds_params):
     ) as f:
         assert response.json() == json.load(f)
 
-
-def test_get_tilejson_test(app):
-    return get_tilejson_test(app, test_zarr_store_params)
-
-
-def test_get_tilejson_netcdf(app):
-    return get_tilejson_test(app, test_netcdf_store_params)
-
-
-def test_get_tilejson_unconsolidated(app):
-    return get_tilejson_test(app, test_unconsolidated_store_params)
-
-
-def test_get_tilejson_pyramid(app):
-    return get_tilejson_test(app, test_pyramid_store_params)
-
+@pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
+def test_get_tilejson(store_params, app):
+    return get_tilejson_test(app, store_params)
 
 def get_tile_test(app, ds_params, zoom: int = 0):
     response = app.get(
@@ -150,24 +116,14 @@ def get_tile_test(app, ds_params, zoom: int = 0):
     assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
     assert timings[2].lstrip().startswith("2-rioxarray-reproject;dur=")
 
-
-def test_get_tile_test(app):
-    return get_tile_test(app, test_zarr_store_params)
-
-
-def test_get_tile_netcdf(app):
-    return get_tile_test(app, test_netcdf_store_params)
-
-
-def test_get_tile_unconsolidated(app):
-    return get_tile_test(app, test_unconsolidated_store_params)
-
-
-def test_get_tile_pyramid(app):
-    # test that even a group outside of the range will return a tile
-    for z in range(3):
-        get_tile_test(app, test_pyramid_store_params, zoom=z)
-
+@pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
+def test_get_tile(store_params, app):
+    # if the store is a pyramid we test zoom levels 0-2
+    if store_params == store_params['pyramid_store']:
+        for z in range(3):
+            get_tile_test(app, store_params, zoom=z)
+    else:
+        get_tile_test(app, store_params)
 
 def histogram_test(app, ds_params):
     response = app.get(
@@ -181,21 +137,9 @@ def histogram_test(app, ds_params):
     ) as f:
         assert response.json() == json.load(f)
 
-
-def test_histogram_test(app):
-    return histogram_test(app, test_zarr_store_params)
-
-
-def test_histogram_netcdf(app):
-    return histogram_test(app, test_netcdf_store_params)
-
-
-def test_histogram_unconsolidated(app):
-    return histogram_test(app, test_unconsolidated_store_params)
-
-
-def test_histogram_pyramid(app):
-    return histogram_test(app, test_pyramid_store_params)
+@pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
+def test_histogram(store_params, app):
+    return histogram_test(app, store_params)
 
 
 def test_histogram_error(app):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -124,7 +124,7 @@ def get_tile_test(app, ds_params, zoom: int = 0):
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_tile(store_params, app):
     # if the store is a pyramid we test zoom levels 0-2
-    if store_params == store_params["pyramid_store"]:
+    if "group" in store_params["params"].keys():
         for z in range(3):
             get_tile_test(app, store_params, zoom=z)
     else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -124,7 +124,7 @@ def get_tile_test(app, ds_params, zoom: int = 0):
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_tile(store_params, app):
     # if the store is a pyramid we test zoom levels 0-2
-    if "group" in store_params["params"].keys():
+    if "group" in store_params["params"]:
         for z in range(3):
             get_tile_test(app, store_params, zoom=z)
     else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,7 +12,7 @@ test_pyramid_store = os.path.join(DATA_DIR, "pyramid.zarr")
 
 store_params = {}
 
-store_params['zarr_store'] = {
+store_params["zarr_store"] = {
     "params": {
         "url": test_zarr_store,
         "variable": "CDD0",
@@ -22,7 +22,7 @@ store_params['zarr_store'] = {
     "variables": ["CDD0", "DISPH", "FROST_DAYS", "GWETPROF"],
 }
 
-store_params['netcdf_store'] = {
+store_params["netcdf_store"] = {
     "params": {
         "url": test_netcdf_store,
         "variable": "data",
@@ -31,7 +31,7 @@ store_params['netcdf_store'] = {
     },
     "variables": ["data"],
 }
-store_params['unconsolidated_store'] = {
+store_params["unconsolidated_store"] = {
     "params": {
         "url": test_unconsolidated_store,
         "variable": "var1",
@@ -40,7 +40,7 @@ store_params['unconsolidated_store'] = {
     },
     "variables": ["var1", "var2"],
 }
-store_params['pyramid_store'] = {
+store_params["pyramid_store"] = {
     "params": {
         "url": test_pyramid_store,
         "variable": "value",
@@ -62,6 +62,7 @@ def get_variables_test(app, ds_params):
     assert timings[0].startswith("total;dur=")
     assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
 
+
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_variables(store_params, app):
     return get_variables_test(app, store_params)
@@ -79,6 +80,7 @@ def get_info_test(app, ds_params):
         "r",
     ) as f:
         assert response.json() == json.load(f)
+
 
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_info(store_params, app):
@@ -99,9 +101,11 @@ def get_tilejson_test(app, ds_params):
     ) as f:
         assert response.json() == json.load(f)
 
+
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_tilejson(store_params, app):
     return get_tilejson_test(app, store_params)
+
 
 def get_tile_test(app, ds_params, zoom: int = 0):
     response = app.get(
@@ -116,14 +120,16 @@ def get_tile_test(app, ds_params, zoom: int = 0):
     assert timings[1].lstrip().startswith("1-xarray-open_dataset;dur=")
     assert timings[2].lstrip().startswith("2-rioxarray-reproject;dur=")
 
+
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_get_tile(store_params, app):
     # if the store is a pyramid we test zoom levels 0-2
-    if store_params == store_params['pyramid_store']:
+    if store_params == store_params["pyramid_store"]:
         for z in range(3):
             get_tile_test(app, store_params, zoom=z)
     else:
         get_tile_test(app, store_params)
+
 
 def histogram_test(app, ds_params):
     response = app.get(
@@ -136,6 +142,7 @@ def histogram_test(app, ds_params):
         "r",
     ) as f:
         assert response.json() == json.load(f)
+
 
 @pytest.mark.parametrize("store_params", store_params.values(), ids=store_params.keys())
 def test_histogram(store_params, app):


### PR DESCRIPTION
While I was hacking away on integrating (virtual) icechunk support into titiler multidim I caught myself having to write a bunch of the same code for new datasets, which was error prone. 

This PR wraps the store specific parameters into a dict and uses that as parametrized input for values and labels in the existing test functions.