### PR TITLE
feat: enable multiple sources, render as a mosaic

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,7 +32,6 @@ jobs:
       TITILER_MULTIDIM_DEBUG: true
       TITILER_MULTIDIM_READER_ROLE_ARN: ${{ vars.TITILER_MULTIDIM_READER_ROLE_ARN }}
       TITILER_MULTIDIM_AUTHORIZED_CHUNK_ACCESS: '{"s3://nasa-waterinsight/NLDAS3/forcing/daily/": {"anonymous": true}, "s3://podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/": {"from_env": true}, "s3://nasa-waterinsight/RASI/": {"anonymous": true}, "s3://noaa-nws-naqfc-pds/": {"anonymous": true}}'
-      TITILER_MULTIDIM_TELEMETRY_ENABLED: true
 
     steps:
       - name: Determine branch to deploy

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -32,6 +32,7 @@ jobs:
       TITILER_MULTIDIM_DEBUG: true
       TITILER_MULTIDIM_READER_ROLE_ARN: ${{ vars.TITILER_MULTIDIM_READER_ROLE_ARN }}
       TITILER_MULTIDIM_AUTHORIZED_CHUNK_ACCESS: '{"s3://nasa-waterinsight/NLDAS3/forcing/daily/": {"anonymous": true}, "s3://podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/": {"from_env": true}, "s3://nasa-waterinsight/RASI/": {"anonymous": true}, "s3://noaa-nws-naqfc-pds/": {"anonymous": true}}'
+      TITILER_MULTIDIM_TELEMETRY_ENABLED: true
 
     steps:
       - name: Determine branch to deploy

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to deploy'
+        description: "Branch to deploy"
         required: true
-        default: 'main'
+        default: "main"
   pull_request:
     types: [labeled, synchronize]
 
@@ -31,7 +31,7 @@ jobs:
       TITILER_MULTIDIM_PYTHONWARNINGS: ignore
       TITILER_MULTIDIM_DEBUG: true
       TITILER_MULTIDIM_READER_ROLE_ARN: ${{ vars.TITILER_MULTIDIM_READER_ROLE_ARN }}
-      TITILER_MULTIDIM_AUTHORIZED_CHUNK_ACCESS: '{"s3://nasa-waterinsight/NLDAS3/forcing/daily/": {"anonymous": true}, "s3://podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/": {"from_env": true}, "s3://nasa-waterinsight/RASI/": {"anonymous": true}}'
+      TITILER_MULTIDIM_AUTHORIZED_CHUNK_ACCESS: '{"s3://nasa-waterinsight/NLDAS3/forcing/daily/": {"anonymous": true}, "s3://podaac-ops-cumulus-protected/MUR-JPL-L4-GLOB-v4.1/": {"from_env": true}, "s3://nasa-waterinsight/RASI/": {"anonymous": true}, "s3://noaa-nws-naqfc-pds/": {"anonymous": true}}'
 
     steps:
       - name: Determine branch to deploy

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ cdk.context.json
 
 .test-deploy-env
 .vscode/settings.json
+
+dev-docs/brainstorms/
+dev-docs/plans/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ uv run uvicorn titiler.multidim.main:app --reload
 To access the docs, visit <http://127.0.0.1:8000/api.html>.
 ![](https://github.com/developmentseed/titiler-multidim/assets/10407788/4368546b-5b60-4cd5-86be-fdd959374b17)
 
+## Mosaic requests
+
+Every Xarray data endpoint accepts one to twenty ordered `url` query values. Reuse the same `variable`, `group`, `decode_times`, and `sel` parameters for each source; no MosaicJSON or STAC manifest is needed. Overlapping valid pixels use the first URL by default (set `pixel_selection` to another supported rio-tiler strategy when needed).
+
+```bash
+curl 'http://127.0.0.1:8000/tiles/WebMercatorQuad/0/0/0.png?url=https%3A%2F%2Fexample.com%2Fpriority.zarr&url=https%3A%2F%2Fexample.com%2Ffallback.zarr&variable=temperature&sel=time%3D0'
+```
+
+All sources must expose compatible selected data.
+
 ## TiTiler 2 migration
 
 TiTiler 2 is a breaking API upgrade:

--- a/infrastructure/aws/lambda/handler.py
+++ b/infrastructure/aws/lambda/handler.py
@@ -304,7 +304,10 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     timeout so a slow X-Ray endpoint cannot push the invocation over
     the function's configured limit.
     """
+    logger = logging.getLogger("titiler.multidim.lambda")
+    logger.info("Lambda request started: request_id=%s", context.aws_request_id)
     result = _mangum(event, context)
+    logger.info("Lambda request completed: request_id=%s", context.aws_request_id)
     if api_settings.telemetry_enabled:
         _provider.force_flush(timeout_millis=5_000)
     return result

--- a/infrastructure/aws/lambda/handler.py
+++ b/infrastructure/aws/lambda/handler.py
@@ -261,7 +261,6 @@ if "AWS_EXECUTION_ENV" in os.environ and api_settings.telemetry_enabled:
     propagate.set_global_textmap(_LambdaXRayPropagator())
 
     LoggingInstrumentor().instrument(set_logging_format=True)
-    # HTTPXClientInstrumentor().instrument()
     FastAPIInstrumentor.instrument_app(app)
 
 # ── SnapStart pre-warming ──────────────────────────────────────────────────────

--- a/infrastructure/aws/lambda/handler.py
+++ b/infrastructure/aws/lambda/handler.py
@@ -141,7 +141,6 @@ if "AWS_EXECUTION_ENV" in os.environ and api_settings.telemetry_enabled:
     from opentelemetry import propagate, trace
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
     from opentelemetry.instrumentation.logging import LoggingInstrumentor
     from opentelemetry.propagators.aws import AwsXRayPropagator
     from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
@@ -262,7 +261,7 @@ if "AWS_EXECUTION_ENV" in os.environ and api_settings.telemetry_enabled:
     propagate.set_global_textmap(_LambdaXRayPropagator())
 
     LoggingInstrumentor().instrument(set_logging_format=True)
-    HTTPXClientInstrumentor().instrument()
+    # HTTPXClientInstrumentor().instrument()
     FastAPIInstrumentor.instrument_app(app)
 
 # ── SnapStart pre-warming ──────────────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ lambda = [
     "aiobotocore>=2.24.0,<2.24.2",
     "opentelemetry-exporter-otlp-proto-http>=1.40.0",
     "opentelemetry-instrumentation-fastapi>=0.61b0",
-    "opentelemetry-instrumentation-httpx>=0.61b0",
     "opentelemetry-instrumentation-logging>=0.61b0",
     "opentelemetry-propagator-aws-xray>=1.0.2",
     "opentelemetry-sdk>=1.40.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ dependencies = [
     "s3fs",
     "xarray>=2025.10.1",
     "zarr>=3.2.0",
+    "titiler-mosaic==2.2.1",
+    "gribberish[zarr]>=1.7.0",
 ]
 
 [project.optional-dependencies]

--- a/src/titiler/multidim/extensions.py
+++ b/src/titiler/multidim/extensions.py
@@ -15,14 +15,10 @@ from titiler.multidim.reader import api_settings, guess_opener
 
 
 def DatasetMetadataPathParams(
-    url: list[str] = Query(
-        min_length=1,
-        max_length=1,
-        description="One Xarray dataset URL.",
-    ),
+    url: str = Query(description="One Xarray dataset URL."),
 ) -> str:
-    """Return the single source URL accepted by dataset metadata endpoints."""
-    return url[0]
+    """Return the source URL accepted by dataset metadata endpoints."""
+    return url
 
 
 def open_metadata_dataset(src_path: str, **kwargs: Any) -> xr.Dataset:

--- a/src/titiler/multidim/extensions.py
+++ b/src/titiler/multidim/extensions.py
@@ -1,0 +1,113 @@
+"""TiTiler extensions adapted for multidimensional mosaics."""
+
+from collections.abc import Callable
+from typing import Annotated, Any
+
+import xarray as xr
+from attrs import define
+from fastapi import Depends, Query
+from starlette.responses import HTMLResponse
+from titiler.core.factory import BaseFactory
+from titiler.core.resources.enums import MediaType
+from titiler.xarray.extensions import ValidateExtension, ValidationInfo
+
+from titiler.multidim.reader import api_settings, guess_opener
+
+
+def DatasetMetadataPathParams(
+    url: list[str] = Query(
+        min_length=1,
+        max_length=1,
+        description="One Xarray dataset URL.",
+    ),
+) -> str:
+    """Return the single source URL accepted by dataset metadata endpoints."""
+    return url[0]
+
+
+def open_metadata_dataset(src_path: str, **kwargs: Any) -> xr.Dataset:
+    """Open a dataset for metadata inspection with configured Icechunk access."""
+    return guess_opener(
+        src_path,
+        authorize_virtual_chunk_access=api_settings.authorized_chunk_access,
+        **kwargs,
+    )
+
+
+@define
+class DatasetMetadataExtension(ValidateExtension):
+    """Register single-source dataset metadata and validation endpoints."""
+
+    dataset_opener: Callable[..., xr.Dataset] = open_metadata_dataset
+
+    def register(self, factory: BaseFactory) -> None:
+        """Register dataset routes without changing the factory's source dependency."""
+
+        @factory.router.get(
+            "/dataset/",
+            responses={
+                200: {
+                    "description": "Returns the HTML representation of the Xarray Dataset.",
+                    "content": {MediaType.html.value: {}},
+                },
+            },
+            response_class=HTMLResponse,
+        )
+        def dataset_metadata_html(
+            src_path=Depends(DatasetMetadataPathParams),
+            io_params=Depends(self.io_dependency),
+        ):
+            """Return the HTML representation of one Xarray Dataset."""
+            with self.dataset_opener(src_path, **io_params.as_dict()) as ds:
+                return HTMLResponse(ds._repr_html_())
+
+        @factory.router.get(
+            "/dataset/dict",
+            responses={
+                200: {"description": "Returns the full Xarray dataset as a dictionary."}
+            },
+        )
+        def dataset_metadata_dict(
+            src_path=Depends(DatasetMetadataPathParams),
+            io_params=Depends(self.io_dependency),
+        ):
+            """Return one Xarray Dataset as a dictionary."""
+            with self.dataset_opener(src_path, **io_params.as_dict()) as ds:
+                return ds.to_dict(data=False)
+
+        @factory.router.get(
+            "/dataset/keys",
+            response_model=list[str],
+            responses={
+                200: {
+                    "description": "Returns the list of keys/variables in the Dataset."
+                }
+            },
+        )
+        def dataset_variables(
+            src_path=Depends(DatasetMetadataPathParams),
+            io_params=Depends(self.io_dependency),
+        ):
+            """Return the data variables in one Xarray Dataset."""
+            with self.dataset_opener(src_path, **io_params.as_dict()) as ds:
+                return list(ds.data_vars)
+
+        @factory.router.get(
+            "/validate",
+            responses={200: {"content": {"application/json": {}}}},
+            response_model=dict[str, ValidationInfo],
+        )
+        def validate_dataset(
+            src_path=Depends(DatasetMetadataPathParams),
+            io_params=Depends(self.io_dependency),
+            variables: Annotated[
+                list[str] | None, Query(description="Xarray Variable name.")
+            ] = None,
+        ):
+            """Validate variables in one Xarray Dataset."""
+            with self.dataset_opener(src_path, **io_params.as_dict()) as ds:
+                variables = variables or list(ds.data_vars)
+                return {
+                    variable: self._validate_variable(ds[variable])
+                    for variable in variables
+                }

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -6,7 +6,6 @@ from urllib.parse import urlencode
 
 import jinja2
 import numpy as np
-import rasterio
 from attrs import define
 from fastapi import Body, Depends, Path, Query
 from geojson_pydantic.features import Feature, FeatureCollection
@@ -53,8 +52,8 @@ def DatasetPathParams(
 
 
 @define(kw_only=True)
-class XarrayTilerFactory(MosaicTilerFactory):
-    """Serve the established Xarray API over one or more Xarray sources."""
+class XarrayMosaicTilerFactory(MosaicTilerFactory):
+    """Xarray Mosaic Tiler Factory"""
 
     backend: type[XarrayMosaicBackend] = XarrayMosaicBackend
     dataset_reader: type[XarrayReader] = XarrayReader
@@ -94,25 +93,23 @@ class XarrayTilerFactory(MosaicTilerFactory):
                 bool | None,
                 Query(description="Show info about the time dimension"),
             ] = None,
-            env=Depends(self.environment_dependency),
         ):
             """Return native source info or aggregate mosaic info."""
-            with rasterio.Env(**env):
-                with self.backend(
-                    src_path,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    info = src.info()
-                    if show_times and len(src_path) == 1:
-                        with self.dataset_reader(
-                            src_path[0], **reader_params.as_dict()
-                        ) as source:
-                            if "time" in source.input.dims:
-                                info["count"] = len(source.input.time)
-                                info["times"] = [
-                                    str(value.data) for value in source.input.time
-                                ]
+            with self.backend(
+                src_path,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                info = src.info()
+                if show_times and len(src_path) == 1:
+                    with self.dataset_reader(
+                        src_path[0], **reader_params.as_dict()
+                    ) as source:
+                        if "time" in source.input.dims:
+                            info["count"] = len(source.input.time)
+                            info["times"] = [
+                                str(value.data) for value in source.input.time
+                            ]
             return info
 
         @self.router.get(
@@ -132,22 +129,20 @@ class XarrayTilerFactory(MosaicTilerFactory):
             src_path=Depends(self.path_dependency),
             reader_params=Depends(self.reader_dependency),
             crs=Depends(CRSParams),
-            env=Depends(self.environment_dependency),
         ):
             """Return native source info or aggregate mosaic info as GeoJSON."""
-            with rasterio.Env(**env):
-                with self.backend(
-                    src_path,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    bounds = src.get_geographic_bounds(crs or WGS84_CRS)
-                    return Feature(
-                        type="Feature",
-                        bbox=bounds,
-                        geometry=bounds_to_geometry(bounds),
-                        properties=src.info(),
-                    )
+            with self.backend(
+                src_path,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                bounds = src.get_geographic_bounds(crs or WGS84_CRS)
+                return Feature(
+                    type="Feature",
+                    bbox=bounds,
+                    geometry=bounds_to_geometry(bounds),
+                    properties=src.info(),
+                )
 
     def tilejson(self) -> None:  # noqa: C901
         """Register a TileJSON endpoint with Xarray metadata."""
@@ -181,7 +176,6 @@ class XarrayTilerFactory(MosaicTilerFactory):
             ] = None,
             src_path=Depends(self.path_dependency),
             reader_params=Depends(self.reader_dependency),
-            env=Depends(self.environment_dependency),
         ):
             """Return a TileJSON document for the requested sources."""
             route_params: dict[str, Any] = {
@@ -204,26 +198,23 @@ class XarrayTilerFactory(MosaicTilerFactory):
             tiles_url += f"?{urlencode(qs)}"
 
             tms = self.supported_tms.get(tileMatrixSetId)
-            with rasterio.Env(**env):
-                with self.backend(
-                    src_path,
-                    tms=tms,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    info = src.info()
-                    return {
-                        "bounds": src.get_geographic_bounds(
-                            tms.rasterio_geographic_crs
-                        ),
-                        "minzoom": minzoom if minzoom is not None else src.minzoom,
-                        "maxzoom": maxzoom if maxzoom is not None else src.maxzoom,
-                        "tiles": [tiles_url],
-                        "raster_layers": self.get_renders(src),
-                        "band_descriptions": info.get("band_descriptions"),
-                        "data_type": info.get("dtype"),
-                        "minmax": info.get("minmax"),
-                    }
+            with self.backend(
+                src_path,
+                tms=tms,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                info = src.info()
+                return {
+                    "bounds": src.get_geographic_bounds(tms.rasterio_geographic_crs),
+                    "minzoom": minzoom if minzoom is not None else src.minzoom,
+                    "maxzoom": maxzoom if maxzoom is not None else src.maxzoom,
+                    "tiles": [tiles_url],
+                    "raster_layers": self.get_renders(src),
+                    "band_descriptions": info.get("band_descriptions"),
+                    "data_type": info.get("dtype"),
+                    "minmax": info.get("minmax"),
+                }
 
     def point(self) -> None:
         """Register a strategy-composited Xarray point endpoint."""
@@ -244,24 +235,22 @@ class XarrayTilerFactory(MosaicTilerFactory):
             layer_params=Depends(self.layer_dependency),
             dataset_params=Depends(self.dataset_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
-            env=Depends(self.environment_dependency),
         ):
             """Return one point response using the requested mosaic strategy."""
-            with rasterio.Env(**env):
-                with self.backend(
-                    src_path,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    point_data, _ = src.point(
-                        lon,
-                        lat,
-                        coord_crs=coord_crs or WGS84_CRS,
-                        pixel_selection=pixel_selection,
-                        threads=MOSAIC_THREADS,
-                        **layer_params.as_dict(),
-                        **dataset_params.as_dict(),
-                    )
+            with self.backend(
+                src_path,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                point_data, _ = src.point(
+                    lon,
+                    lat,
+                    coord_crs=coord_crs or WGS84_CRS,
+                    pixel_selection=pixel_selection,
+                    threads=MOSAIC_THREADS,
+                    **layer_params.as_dict(),
+                    **dataset_params.as_dict(),
+                )
             return {
                 "coordinates": [lon, lat],
                 "values": point_data.array.tolist(),
@@ -302,7 +291,6 @@ class XarrayTilerFactory(MosaicTilerFactory):
             post_process=Depends(self.process_dependency),
             stats_params=Depends(self.stats_dependency),
             histogram_params=Depends(self.histogram_dependency),
-            env=Depends(self.environment_dependency),
         ):
             """Calculate statistics from composited feature pixels."""
             collection = (
@@ -310,38 +298,37 @@ class XarrayTilerFactory(MosaicTilerFactory):
                 if isinstance(geojson, Feature)
                 else geojson
             )
-            with rasterio.Env(**env):
-                with self.backend(
-                    src_path,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    for feature in collection.features:
-                        shape = feature.model_dump(exclude_none=True)
-                        image, _ = src.feature(
-                            shape,
-                            shape_crs=coord_crs or WGS84_CRS,
-                            dst_crs=dst_crs,
-                            align_bounds_with_dataset=True,
-                            pixel_selection=pixel_selection,
-                            threads=MOSAIC_THREADS,
-                            **layer_params.as_dict(),
-                            **dataset_params.as_dict(),
-                            **image_params.as_dict(),
-                        )
-                        coverage = image.get_coverage_array(
-                            shape,
-                            shape_crs=coord_crs or WGS84_CRS,
-                            cover_scale=cover_scale,
-                        )
-                        if post_process:
-                            image = post_process(image)
-                        feature.properties = feature.properties or {}
-                        feature.properties["statistics"] = image.statistics(
-                            **stats_params.as_dict(),
-                            hist_options=histogram_params.as_dict(),
-                            coverage=coverage,
-                        )
+            with self.backend(
+                src_path,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                for feature in collection.features:
+                    shape = feature.model_dump(exclude_none=True)
+                    image, _ = src.feature(
+                        shape,
+                        shape_crs=coord_crs or WGS84_CRS,
+                        dst_crs=dst_crs,
+                        align_bounds_with_dataset=True,
+                        pixel_selection=pixel_selection,
+                        threads=MOSAIC_THREADS,
+                        **layer_params.as_dict(),
+                        **dataset_params.as_dict(),
+                        **image_params.as_dict(),
+                    )
+                    coverage = image.get_coverage_array(
+                        shape,
+                        shape_crs=coord_crs or WGS84_CRS,
+                        cover_scale=cover_scale,
+                    )
+                    if post_process:
+                        image = post_process(image)
+                    feature.properties = feature.properties or {}
+                    feature.properties["statistics"] = image.statistics(
+                        **stats_params.as_dict(),
+                        hist_options=histogram_params.as_dict(),
+                        coverage=coverage,
+                    )
             return (
                 collection.features[0] if isinstance(geojson, Feature) else collection
             )
@@ -356,27 +343,23 @@ class XarrayTilerFactory(MosaicTilerFactory):
             src_path=Depends(self.path_dependency),
             reader_params=Depends(self.reader_dependency),
             pixel_selection=Depends(self.pixel_selection_dependency),
-            env=Depends(self.environment_dependency),
         ):
             """Return a native or strategy-composited ten-bucket histogram."""
-            with rasterio.Env(**env):
-                if len(src_path) == 1:
-                    with self.dataset_reader(
-                        src_path[0], **reader_params.as_dict()
-                    ) as src:
-                        values = src.input.values[~np.isnan(src.input)]
-                else:
-                    with self.backend(
-                        src_path,
-                        reader=self.dataset_reader,
-                        reader_options=reader_params.as_dict(),
-                    ) as src:
-                        image, _ = src.part(
-                            src.bounds,
-                            pixel_selection=pixel_selection,
-                            threads=MOSAIC_THREADS,
-                        )
-                        values = image.array.compressed()
+            if len(src_path) == 1:
+                with self.dataset_reader(src_path[0], **reader_params.as_dict()) as src:
+                    values = src.input.values[~np.isnan(src.input)]
+            else:
+                with self.backend(
+                    src_path,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    image, _ = src.part(
+                        src.bounds,
+                        pixel_selection=pixel_selection,
+                        threads=MOSAIC_THREADS,
+                    )
+                    values = image.array.compressed()
             counts, edges = np.histogram(values, bins=10)
             return [
                 {"bucket": edges[index : index + 2].tolist(), "value": count}

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -89,7 +89,9 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
             reader_params=Depends(self.reader_dependency),
             show_times: Annotated[
                 bool | None,
-                Query(description="Show info about the time dimension (only available for single URLs"),
+                Query(
+                    description="Show info about the time dimension (only available for single URLs"
+                ),
             ] = None,
         ):
             """Return native source info or aggregate mosaic info."""
@@ -293,6 +295,7 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
                             west, east
                         )
                     ]
+                )
 
             counts, edges = np.histogram(values, bins=10)
 

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -1,60 +1,350 @@
-"""TiTiler.xarray factory."""
+"""TiTiler Xarray mosaic factory."""
 
-from typing import List, Literal, Optional, Type
+from collections.abc import Callable
+from typing import Annotated, Any, Literal
 from urllib.parse import urlencode
 
 import jinja2
 import numpy as np
+import rasterio
 from attrs import define
-from fastapi import Depends, Query
+from fastapi import Body, Depends, Path, Query
+from geojson_pydantic.features import Feature, FeatureCollection
+from rio_tiler.constants import WGS84_CRS
+from rio_tiler.models import Info
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 from starlette.templating import Jinja2Templates
-from typing_extensions import Annotated
-
-from titiler.core.dependencies import DefaultDependency
+from titiler.core.dependencies import (
+    BidxParams,
+    CoordCRSParams,
+    CoverScaleParams,
+    CRSParams,
+    DefaultDependency,
+    DstCRSParams,
+)
+from titiler.core.errors import BadRequestError
+from titiler.core.models.mapbox import TileJSON
+from titiler.core.models.responses import InfoGeoJSON, Point, StatisticsGeoJSON
 from titiler.core.resources.enums import ImageType
-from titiler.core.resources.responses import JSONResponse
+from titiler.core.resources.responses import GeoJSONResponse, JSONResponse
+from titiler.core.utils import bounds_to_geometry
+from titiler.mosaic.factory import MOSAIC_THREADS, MosaicTilerFactory
+from titiler.xarray.dependencies import (
+    DatasetParams,
+    PartFeatureParams,
+    XarrayIOParams,
+    XarrayParams,
+)
+
+from titiler.multidim.mosaic import XarrayMosaicBackend
 from titiler.multidim.reader import XarrayReader
-from titiler.xarray.dependencies import DatasetParams, XarrayIOParams, XarrayParams
-from titiler.xarray.factory import TilerFactory as BaseTilerFactory
+
+
+def DatasetPathParams(
+    url: list[str] = Query(
+        min_length=1,
+        max_length=20,
+        description="One to twenty ordered Xarray dataset URLs.",
+    ),
+) -> list[str]:
+    """Return the ordered Xarray source URLs."""
+    return url
 
 
 @define(kw_only=True)
-class XarrayTilerFactory(BaseTilerFactory):
-    """Xarray Tiler Factory."""
+class XarrayTilerFactory(MosaicTilerFactory):
+    """Serve the established Xarray API over one or more Xarray sources."""
 
-    reader: Type[XarrayReader] = XarrayReader
-    reader_dependency: Type[DefaultDependency] = XarrayParams
-    dataset_dependency: Type[DefaultDependency] = DatasetParams
+    backend: type[XarrayMosaicBackend] = XarrayMosaicBackend
+    dataset_reader: type[XarrayReader] = XarrayReader
+    path_dependency: Callable[..., list[str]] = DatasetPathParams
+    reader_dependency: type[DefaultDependency] = XarrayParams
+    layer_dependency: type[DefaultDependency] = BidxParams
+    dataset_dependency: type[DefaultDependency] = DatasetParams
+    img_part_dependency: type[DefaultDependency] = PartFeatureParams
 
-    def register_routes(self) -> None:  # noqa: C901
-        """Register Info / Tiles / TileJSON endoints."""
-        super().register_routes()
+    def register_routes(self) -> None:
+        """Register the Xarray route surface, without MosaicJSON asset routes."""
+        self.info()
+        self.tilesets()
+        self.tile()
+        self.map_viewer()
+        self.tilejson()
+        self.point()
+        self.part()
+        self.statistics()
         self.variables()
 
-    def variables(self) -> None:
-        """Register /variables endpoint"""
+    def info(self) -> None:
+        """Register Xarray-shaped info endpoints."""
 
         @self.router.get(
-            "/variables",
+            "/info",
+            response_model=Info,
+            response_model_exclude_none=True,
             response_class=JSONResponse,
-            responses={200: {"description": "Return dataset's Variables."}},
+            responses={200: {"description": "Return dataset's basic info."}},
+            operation_id=f"{self.operation_prefix}getInfo",
         )
-        def get_variables(
+        def info_endpoint(
             src_path=Depends(self.path_dependency),
-            io_params=Depends(XarrayIOParams),
-        ) -> List[str]:
-            """return available variables."""
-            return self.reader.list_variables(
-                src_path=src_path,
-                group=io_params.group,
-                decode_times=io_params.decode_times,
-            )
+            reader_params=Depends(self.reader_dependency),
+            show_times: Annotated[
+                bool | None,
+                Query(description="Show info about the time dimension"),
+            ] = None,
+            env=Depends(self.environment_dependency),
+        ):
+            """Return native source info or aggregate mosaic info."""
+            with rasterio.Env(**env):
+                with self.backend(
+                    src_path,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    info = src.info()
+                    if show_times and len(src_path) == 1:
+                        with self.dataset_reader(
+                            src_path[0], **reader_params.as_dict()
+                        ) as source:
+                            if "time" in source.input.dims:
+                                info["count"] = len(source.input.time)
+                                info["times"] = [
+                                    str(value.data) for value in source.input.time
+                                ]
+            return info
+
+        @self.router.get(
+            "/info.geojson",
+            response_model=InfoGeoJSON,
+            response_model_exclude_none=True,
+            response_class=GeoJSONResponse,
+            responses={
+                200: {
+                    "content": {"application/geo+json": {}},
+                    "description": "Return dataset's basic info as a GeoJSON feature.",
+                }
+            },
+            operation_id=f"{self.operation_prefix}getInfoGeoJSON",
+        )
+        def info_geojson(
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            crs=Depends(CRSParams),
+            env=Depends(self.environment_dependency),
+        ):
+            """Return native source info or aggregate mosaic info as GeoJSON."""
+            with rasterio.Env(**env):
+                with self.backend(
+                    src_path,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    bounds = src.get_geographic_bounds(crs or WGS84_CRS)
+                    return Feature(
+                        type="Feature",
+                        bbox=bounds,
+                        geometry=bounds_to_geometry(bounds),
+                        properties=src.info(),
+                    )
+
+    def tilejson(self) -> None:  # noqa: C901
+        """Register a TileJSON endpoint with Xarray metadata."""
+
+        @self.router.get(
+            "/{tileMatrixSetId}/tilejson.json",
+            response_model=TileJSON,
+            responses={200: {"description": "Return a tilejson"}},
+            response_model_exclude_none=True,
+            operation_id=f"{self.operation_prefix}getTileJSON",
+        )
+        def tilejson(
+            request: Request,
+            tileMatrixSetId: Annotated[  # type: ignore
+                Literal[tuple(self.supported_tms.list())],
+                Path(description="Identifier selecting a supported TileMatrixSetId."),
+            ],
+            tilesize: Annotated[
+                int | None,
+                Query(gt=0, description="Tilesize in pixels. Default to 512."),
+            ] = 512,
+            tile_format: Annotated[
+                ImageType | None,
+                Query(description="Output image format."),
+            ] = None,
+            minzoom: Annotated[
+                int | None, Query(description="Overwrite minzoom.")
+            ] = None,
+            maxzoom: Annotated[
+                int | None, Query(description="Overwrite maxzoom.")
+            ] = None,
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            env=Depends(self.environment_dependency),
+        ):
+            """Return a TileJSON document for the requested sources."""
+            route_params: dict[str, Any] = {
+                "z": "{z}",
+                "x": "{x}",
+                "y": "{y}",
+                "tileMatrixSetId": tileMatrixSetId,
+            }
+            if tile_format:
+                route_params["format"] = tile_format.value
+            tiles_url = self.url_for(request, "tile", **route_params)
+            qs = [
+                (key, value)
+                for key, value in request.query_params._list
+                if key.lower()
+                not in {"tilematrixsetid", "tile_format", "minzoom", "maxzoom"}
+            ]
+            if "tilesize" not in request.query_params:
+                qs.append(("tilesize", str(tilesize)))
+            tiles_url += f"?{urlencode(qs)}"
+
+            tms = self.supported_tms.get(tileMatrixSetId)
+            with rasterio.Env(**env):
+                with self.backend(
+                    src_path,
+                    tms=tms,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    info = src.info()
+                    return {
+                        "bounds": src.get_geographic_bounds(
+                            tms.rasterio_geographic_crs
+                        ),
+                        "minzoom": minzoom if minzoom is not None else src.minzoom,
+                        "maxzoom": maxzoom if maxzoom is not None else src.maxzoom,
+                        "tiles": [tiles_url],
+                        "raster_layers": self.get_renders(src),
+                        "band_descriptions": info.get("band_descriptions"),
+                        "data_type": info.get("dtype"),
+                        "minmax": info.get("minmax"),
+                    }
+
+    def point(self) -> None:
+        """Register a strategy-composited Xarray point endpoint."""
+
+        @self.router.get(
+            "/point/{lon},{lat}",
+            response_model=Point,
+            response_class=JSONResponse,
+            responses={200: {"description": "Return a value for a point"}},
+            operation_id=f"{self.operation_prefix}getDataForPoint",
+        )
+        def point(
+            lon: float,
+            lat: float,
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            layer_params=Depends(self.layer_dependency),
+            dataset_params=Depends(self.dataset_dependency),
+            pixel_selection=Depends(self.pixel_selection_dependency),
+            env=Depends(self.environment_dependency),
+        ):
+            """Return one point response using the requested mosaic strategy."""
+            with rasterio.Env(**env):
+                with self.backend(
+                    src_path,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    point_data, _ = src.point(
+                        lon,
+                        lat,
+                        coord_crs=coord_crs or WGS84_CRS,
+                        pixel_selection=pixel_selection,
+                        threads=MOSAIC_THREADS,
+                        **layer_params.as_dict(),
+                        **dataset_params.as_dict(),
+                    )
+            return {
+                "coordinates": [lon, lat],
+                "values": point_data.array.tolist(),
+                "band_names": point_data.band_names,
+                "band_descriptions": point_data.band_descriptions,
+            }
 
     def statistics(self) -> None:
-        """Register /statistics and /histogram endpoints"""
-        super().statistics()
+        """Register strategy-composited statistics without mosaic-only fields."""
+
+        @self.router.post(
+            "/statistics",
+            response_model=StatisticsGeoJSON,
+            response_model_exclude_none=True,
+            response_class=GeoJSONResponse,
+            responses={
+                200: {
+                    "content": {"application/geo+json": {}},
+                    "description": "Return statistics for geojson features.",
+                }
+            },
+            operation_id=f"{self.operation_prefix}postStatisticsForGeoJSON",
+        )
+        def geojson_statistics(
+            geojson: Annotated[
+                FeatureCollection | Feature,
+                Body(description="GeoJSON Feature or FeatureCollection."),
+            ],
+            src_path=Depends(self.path_dependency),
+            reader_params=Depends(self.reader_dependency),
+            coord_crs=Depends(CoordCRSParams),
+            dst_crs=Depends(DstCRSParams),
+            layer_params=Depends(self.layer_dependency),
+            dataset_params=Depends(self.dataset_dependency),
+            pixel_selection=Depends(self.pixel_selection_dependency),
+            image_params=Depends(self.img_part_dependency),
+            cover_scale=Depends(CoverScaleParams),
+            post_process=Depends(self.process_dependency),
+            stats_params=Depends(self.stats_dependency),
+            histogram_params=Depends(self.histogram_dependency),
+            env=Depends(self.environment_dependency),
+        ):
+            """Calculate statistics from composited feature pixels."""
+            collection = (
+                FeatureCollection(type="FeatureCollection", features=[geojson])
+                if isinstance(geojson, Feature)
+                else geojson
+            )
+            with rasterio.Env(**env):
+                with self.backend(
+                    src_path,
+                    reader=self.dataset_reader,
+                    reader_options=reader_params.as_dict(),
+                ) as src:
+                    for feature in collection.features:
+                        shape = feature.model_dump(exclude_none=True)
+                        image, _ = src.feature(
+                            shape,
+                            shape_crs=coord_crs or WGS84_CRS,
+                            dst_crs=dst_crs,
+                            align_bounds_with_dataset=True,
+                            pixel_selection=pixel_selection,
+                            threads=MOSAIC_THREADS,
+                            **layer_params.as_dict(),
+                            **dataset_params.as_dict(),
+                            **image_params.as_dict(),
+                        )
+                        coverage = image.get_coverage_array(
+                            shape,
+                            shape_crs=coord_crs or WGS84_CRS,
+                            cover_scale=cover_scale,
+                        )
+                        if post_process:
+                            image = post_process(image)
+                        feature.properties = feature.properties or {}
+                        feature.properties["statistics"] = image.statistics(
+                            **stats_params.as_dict(),
+                            hist_options=histogram_params.as_dict(),
+                            coverage=coverage,
+                        )
+            return (
+                collection.features[0] if isinstance(geojson, Feature) else collection
+            )
 
         @self.router.get(
             "/histogram",
@@ -65,28 +355,63 @@ class XarrayTilerFactory(BaseTilerFactory):
         def histogram(
             src_path=Depends(self.path_dependency),
             reader_params=Depends(self.reader_dependency),
+            pixel_selection=Depends(self.pixel_selection_dependency),
+            env=Depends(self.environment_dependency),
         ):
-            with self.reader(
-                src_path=src_path,
-                variable=reader_params.variable,
-                group=reader_params.group,
-                decode_times=reader_params.decode_times,
-                sel=reader_params.sel,
-            ) as src_dst:
-                boolean_mask = ~np.isnan(src_dst.input)
-                data_values = src_dst.input.values[boolean_mask]
-                counts, values = np.histogram(data_values, bins=10)
-                counts, values = counts.tolist(), values.tolist()
-                buckets = list(
-                    zip(values, [values[i + 1] for i in range(len(values) - 1)])
+            """Return a native or strategy-composited ten-bucket histogram."""
+            with rasterio.Env(**env):
+                if len(src_path) == 1:
+                    with self.dataset_reader(
+                        src_path[0], **reader_params.as_dict()
+                    ) as src:
+                        values = src.input.values[~np.isnan(src.input)]
+                else:
+                    with self.backend(
+                        src_path,
+                        reader=self.dataset_reader,
+                        reader_options=reader_params.as_dict(),
+                    ) as src:
+                        image, _ = src.part(
+                            src.bounds,
+                            pixel_selection=pixel_selection,
+                            threads=MOSAIC_THREADS,
+                        )
+                        values = image.array.compressed()
+            counts, edges = np.histogram(values, bins=10)
+            return [
+                {"bucket": edges[index : index + 2].tolist(), "value": count}
+                for index, count in enumerate(counts.tolist())
+            ]
+
+    def variables(self) -> None:
+        """Register the shared-variable endpoint."""
+
+        @self.router.get(
+            "/variables",
+            response_class=JSONResponse,
+            responses={200: {"description": "Return dataset variables."}},
+        )
+        def get_variables(
+            src_path=Depends(self.path_dependency),
+            io_params=Depends(XarrayIOParams),
+        ) -> list[str]:
+            """Return variables shared by every requested source."""
+            variables = [
+                self.dataset_reader.list_variables(
+                    src_path=path,
+                    group=io_params.group,
+                    decode_times=io_params.decode_times,
                 )
-                hist_dict = []
-                for idx, bucket in enumerate(buckets):
-                    hist_dict.append({"bucket": bucket, "value": counts[idx]})
-                return hist_dict
+                for path in src_path
+            ]
+            if any(set(current) != set(variables[0]) for current in variables[1:]):
+                raise BadRequestError(
+                    "Requested Xarray sources have different variables."
+                )
+            return variables[0]
 
     def map_viewer(self) -> None:
-        """Register /map.html endpoint and redirect legacy /map URLs."""
+        """Register /map.html and redirect legacy /map URLs."""
 
         @self.router.get("/{tileMatrixSetId}/map", include_in_schema=False)
         def map_redirect(request: Request, tileMatrixSetId: str):
@@ -103,54 +428,44 @@ class XarrayTilerFactory(BaseTilerFactory):
                 Literal[tuple(self.supported_tms.list())],
                 "Identifier selecting one of the supported TileMatrixSetIds",
             ],
-            url: Annotated[Optional[str], Query(description="Dataset URL")] = None,
+            url: Annotated[
+                list[str] | None,
+                Query(description="Ordered Xarray dataset URLs"),
+            ] = None,
             variable: Annotated[
-                Optional[str],
-                Query(description="Xarray Variable"),
+                str | None, Query(description="Xarray Variable")
             ] = None,
             group: Annotated[
-                Optional[int],
-                Query(
-                    description="Select a specific zarr group from a zarr hierarchy, can be for pyramids or datasets. Can be used to open a dataset in HDF5 files."
-                ),
+                str | None,
+                Query(description="Select a specific zarr group."),
             ] = None,
             decode_times: Annotated[
                 bool,
-                Query(
-                    title="decode_times",
-                    description="Whether to decode times",
-                ),
+                Query(description="Whether to decode times"),
             ] = True,
             sel: Annotated[
-                Optional[List[str]],
-                Query(
-                    description="Xarray Indexing using `{dimension}={value}` or `{dimension}={method}::{value}`.",
-                ),
+                list[str] | None,
+                Query(description="Xarray indexing using `{dimension}={value}`."),
             ] = None,
             tile_format: Annotated[
-                Optional[ImageType],
-                Query(
-                    description="Default will be automatically defined if the output image needs a mask (png) or not (jpeg).",
-                ),
+                ImageType | None,
+                Query(description="Default output image format."),
             ] = None,
             tilesize: Annotated[
-                int,
-                Query(gt=0, description="Tilesize in pixels. Default to 256."),
+                int, Query(gt=0, description="Tilesize in pixels.")
             ] = 256,
             minzoom: Annotated[
-                Optional[int],
-                Query(description="Overwrite default minzoom."),
+                int | None, Query(description="Overwrite minzoom.")
             ] = None,
             maxzoom: Annotated[
-                Optional[int],
-                Query(description="Overwrite default maxzoom."),
+                int | None, Query(description="Overwrite maxzoom.")
             ] = None,
             post_process=Depends(self.process_dependency),
             colormap=Depends(self.colormap_dependency),
             render_params=Depends(self.render_dependency),
             dataset_params=Depends(self.dataset_dependency),
         ):
-            """Return map Viewer."""
+            """Return the existing map viewer or form."""
             titiler_templates = Jinja2Templates(
                 env=jinja2.Environment(
                     loader=jinja2.ChoiceLoader([jinja2.PackageLoader("titiler.core")])
@@ -161,18 +476,17 @@ class XarrayTilerFactory(BaseTilerFactory):
                     loader=jinja2.ChoiceLoader([jinja2.PackageLoader(__package__, ".")])
                 )
             )
-
             if url:
                 tilejson_url = self.url_for(
                     request, "tilejson", tileMatrixSetId=tileMatrixSetId
                 )
-                qs = list(request.query_params._list)
+                query = list(request.query_params._list)
                 if "tilesize" not in request.query_params:
-                    qs.append(("tilesize", tilesize))
-                tilejson_url += f"?{urlencode(qs)}"
+                    query.append(("tilesize", tilesize))
+                tilejson_url += f"?{urlencode(query)}"
 
                 point_url = self.url_for(request, "point", lon="{lon}", lat="{lat}")
-                point_qs = [
+                point_query = [
                     (key, value)
                     for key, value in request.query_params._list
                     if key.lower()
@@ -187,8 +501,7 @@ class XarrayTilerFactory(BaseTilerFactory):
                         "colormap_name",
                     }
                 ]
-                point_url += f"?{urlencode(point_qs)}"
-
+                point_url += f"?{urlencode(point_query)}"
                 tms = self.supported_tms.get(tileMatrixSetId)
                 return titiler_templates.TemplateResponse(
                     request,
@@ -202,12 +515,9 @@ class XarrayTilerFactory(BaseTilerFactory):
                     },
                     media_type="text/html",
                 )
-            else:
-                return local_templates.TemplateResponse(
-                    request,
-                    name="map-form.html",
-                    context={
-                        "request": request,
-                    },
-                    media_type="text/html",
-                )
+            return local_templates.TemplateResponse(
+                request,
+                name="map-form.html",
+                context={"request": request},
+                media_type="text/html",
+            )

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -7,8 +7,8 @@ from urllib.parse import urlencode
 import jinja2
 import numpy as np
 from attrs import define
-from fastapi import Body, Depends, Path, Query
-from geojson_pydantic.features import Feature, FeatureCollection
+from fastapi import Depends, Path, Query
+from geojson_pydantic.features import Feature
 from rio_tiler.constants import WGS84_CRS
 from rio_tiler.models import Info
 from starlette.requests import Request
@@ -17,14 +17,12 @@ from starlette.templating import Jinja2Templates
 from titiler.core.dependencies import (
     BidxParams,
     CoordCRSParams,
-    CoverScaleParams,
     CRSParams,
     DefaultDependency,
-    DstCRSParams,
 )
 from titiler.core.errors import BadRequestError
 from titiler.core.models.mapbox import TileJSON
-from titiler.core.models.responses import InfoGeoJSON, Point, StatisticsGeoJSON
+from titiler.core.models.responses import InfoGeoJSON, Point
 from titiler.core.resources.enums import ImageType
 from titiler.core.resources.responses import GeoJSONResponse, JSONResponse
 from titiler.core.utils import bounds_to_geometry
@@ -261,77 +259,7 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
     def statistics(self) -> None:
         """Register strategy-composited statistics without mosaic-only fields."""
 
-        @self.router.post(
-            "/statistics",
-            response_model=StatisticsGeoJSON,
-            response_model_exclude_none=True,
-            response_class=GeoJSONResponse,
-            responses={
-                200: {
-                    "content": {"application/geo+json": {}},
-                    "description": "Return statistics for geojson features.",
-                }
-            },
-            operation_id=f"{self.operation_prefix}postStatisticsForGeoJSON",
-        )
-        def geojson_statistics(
-            geojson: Annotated[
-                FeatureCollection | Feature,
-                Body(description="GeoJSON Feature or FeatureCollection."),
-            ],
-            src_path=Depends(self.path_dependency),
-            reader_params=Depends(self.reader_dependency),
-            coord_crs=Depends(CoordCRSParams),
-            dst_crs=Depends(DstCRSParams),
-            layer_params=Depends(self.layer_dependency),
-            dataset_params=Depends(self.dataset_dependency),
-            pixel_selection=Depends(self.pixel_selection_dependency),
-            image_params=Depends(self.img_part_dependency),
-            cover_scale=Depends(CoverScaleParams),
-            post_process=Depends(self.process_dependency),
-            stats_params=Depends(self.stats_dependency),
-            histogram_params=Depends(self.histogram_dependency),
-        ):
-            """Calculate statistics from composited feature pixels."""
-            collection = (
-                FeatureCollection(type="FeatureCollection", features=[geojson])
-                if isinstance(geojson, Feature)
-                else geojson
-            )
-            with self.backend(
-                src_path,
-                reader=self.dataset_reader,
-                reader_options=reader_params.as_dict(),
-            ) as src:
-                for feature in collection.features:
-                    shape = feature.model_dump(exclude_none=True)
-                    image, _ = src.feature(
-                        shape,
-                        shape_crs=coord_crs or WGS84_CRS,
-                        dst_crs=dst_crs,
-                        align_bounds_with_dataset=True,
-                        pixel_selection=pixel_selection,
-                        threads=MOSAIC_THREADS,
-                        **layer_params.as_dict(),
-                        **dataset_params.as_dict(),
-                        **image_params.as_dict(),
-                    )
-                    coverage = image.get_coverage_array(
-                        shape,
-                        shape_crs=coord_crs or WGS84_CRS,
-                        cover_scale=cover_scale,
-                    )
-                    if post_process:
-                        image = post_process(image)
-                    feature.properties = feature.properties or {}
-                    feature.properties["statistics"] = image.statistics(
-                        **stats_params.as_dict(),
-                        hist_options=histogram_params.as_dict(),
-                        coverage=coverage,
-                    )
-            return (
-                collection.features[0] if isinstance(geojson, Feature) else collection
-            )
+        super().statistics()
 
         @self.router.get(
             "/histogram",
@@ -345,22 +273,20 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
             pixel_selection=Depends(self.pixel_selection_dependency),
         ):
             """Return a native or strategy-composited ten-bucket histogram."""
-            if len(src_path) == 1:
-                with self.dataset_reader(src_path[0], **reader_params.as_dict()) as src:
-                    values = src.input.values[~np.isnan(src.input)]
-            else:
-                with self.backend(
-                    src_path,
-                    reader=self.dataset_reader,
-                    reader_options=reader_params.as_dict(),
-                ) as src:
-                    image, _ = src.part(
-                        src.bounds,
-                        pixel_selection=pixel_selection,
-                        threads=MOSAIC_THREADS,
-                    )
-                    values = image.array.compressed()
+            with self.backend(
+                src_path,
+                reader=self.dataset_reader,
+                reader_options=reader_params.as_dict(),
+            ) as src:
+                image, _ = src.part(
+                    src.bounds,
+                    pixel_selection=pixel_selection,
+                    threads=MOSAIC_THREADS,
+                )
+                values = image.array.compressed()
+
             counts, edges = np.histogram(values, bins=10)
+
             return [
                 {"bucket": edges[index : index + 2].tolist(), "value": count}
                 for index, count in enumerate(counts.tolist())

--- a/src/titiler/multidim/factory.py
+++ b/src/titiler/multidim/factory.py
@@ -89,7 +89,7 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
             reader_params=Depends(self.reader_dependency),
             show_times: Annotated[
                 bool | None,
-                Query(description="Show info about the time dimension"),
+                Query(description="Show info about the time dimension (only available for single URLs"),
             ] = None,
         ):
             """Return native source info or aggregate mosaic info."""
@@ -278,12 +278,21 @@ class XarrayMosaicTilerFactory(MosaicTilerFactory):
                 reader=self.dataset_reader,
                 reader_options=reader_params.as_dict(),
             ) as src:
-                image, _ = src.part(
-                    src.bounds,
-                    pixel_selection=pixel_selection,
-                    threads=MOSAIC_THREADS,
-                )
-                values = image.array.compressed()
+                # Antimeridian-crossing mosaics report wrapped bounds
+                # (west > east), which part() cannot window; read each side
+                # of the dateline separately and pool the unmasked values.
+                west, south, east, north = src.bounds
+                values = np.concatenate(
+                    [
+                        src.part(
+                            (interval_west, south, interval_east, north),
+                            pixel_selection=pixel_selection,
+                            threads=MOSAIC_THREADS,
+                        )[0].array.compressed()
+                        for interval_west, interval_east in src._longitude_intervals(
+                            west, east
+                        )
+                    ]
 
             counts, edges = np.histogram(values, bins=10)
 

--- a/src/titiler/multidim/main.py
+++ b/src/titiler/multidim/main.py
@@ -14,6 +14,7 @@ from titiler.core.middleware import (
     LoggerMiddleware,
     TotalTimeMiddleware,
 )
+from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
 from titiler.multidim import __version__ as titiler_version
 from titiler.multidim.extensions import DatasetMetadataExtension
@@ -71,6 +72,7 @@ error_codes = {
 }
 add_exception_handlers(app, error_codes)
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
+add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
 # Set all CORS enabled origins
 if api_settings.cors_origins:

--- a/src/titiler/multidim/main.py
+++ b/src/titiler/multidim/main.py
@@ -15,6 +15,7 @@ from titiler.core.middleware import (
 )
 
 from titiler.multidim import __version__ as titiler_version
+from titiler.multidim.extensions import DatasetMetadataExtension
 from titiler.multidim.factory import XarrayMosaicTilerFactory
 from titiler.multidim.redis_pool import get_redis
 from titiler.multidim.settings import ApiSettings
@@ -36,7 +37,8 @@ app = FastAPI(
 ###############################################################################
 # Tiles endpoints
 xarray_factory = XarrayMosaicTilerFactory(
-    enable_telemetry=api_settings.telemetry_enabled
+    enable_telemetry=api_settings.telemetry_enabled,
+    extensions=[DatasetMetadataExtension()],
 )
 app.include_router(xarray_factory.router, tags=["Xarray Tiler API"])
 

--- a/src/titiler/multidim/main.py
+++ b/src/titiler/multidim/main.py
@@ -1,6 +1,7 @@
 """titiler.multidim."""
 
 import logging
+import os
 
 import zarr
 from fastapi import Depends, FastAPI
@@ -22,9 +23,14 @@ from titiler.multidim.settings import ApiSettings
 
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
-logging.getLogger("rio-tiler").setLevel(logging.ERROR)
+logging.getLogger("rio_tiler").setLevel(logging.INFO)
 
 api_settings = ApiSettings()
+
+if "AWS_EXECUTION_ENV" not in os.environ:
+    logging.basicConfig(
+        level=logging.DEBUG if api_settings.debug else logging.INFO,
+    )
 
 app = FastAPI(
     title=api_settings.name,
@@ -106,3 +112,16 @@ def clear_cache(cache_client=Depends(get_redis)):
     """Clear the cache."""
     cache_client.flushall()
     return {"status": "cache cleared!"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    log_level = "debug" if api_settings.debug else "info"
+    uvicorn.run(
+        "titiler.multidim.main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level=log_level,
+    )

--- a/src/titiler/multidim/main.py
+++ b/src/titiler/multidim/main.py
@@ -15,7 +15,7 @@ from titiler.core.middleware import (
 )
 
 from titiler.multidim import __version__ as titiler_version
-from titiler.multidim.factory import XarrayTilerFactory
+from titiler.multidim.factory import XarrayMosaicTilerFactory
 from titiler.multidim.redis_pool import get_redis
 from titiler.multidim.settings import ApiSettings
 
@@ -35,7 +35,9 @@ app = FastAPI(
 
 ###############################################################################
 # Tiles endpoints
-xarray_factory = XarrayTilerFactory(enable_telemetry=api_settings.telemetry_enabled)
+xarray_factory = XarrayMosaicTilerFactory(
+    enable_telemetry=api_settings.telemetry_enabled
+)
 app.include_router(xarray_factory.router, tags=["Xarray Tiler API"])
 
 ###############################################################################

--- a/src/titiler/multidim/mosaic.py
+++ b/src/titiler/multidim/mosaic.py
@@ -40,7 +40,6 @@ class XarrayMosaicBackend(BaseBackend):
                         for dimension in src.input.dims
                         if dimension not in {src.input.rio.x_dim, src.input.rio.y_dim}
                     ),
-                    tuple(src.band_descriptions),
                     repr(info["band_metadata"]),
                     info["nodata_type"],
                 )
@@ -53,12 +52,7 @@ class XarrayMosaicBackend(BaseBackend):
                 zooms.append((src.minzoom, src.maxzoom))
 
         self.crs = WGS84_CRS
-        self.bounds = (
-            min(bounds[0] for bounds in self._asset_bounds),
-            min(bounds[1] for bounds in self._asset_bounds),
-            max(bounds[2] for bounds in self._asset_bounds),
-            max(bounds[3] for bounds in self._asset_bounds),
-        )
+        self.bounds = self._mosaic_bounds()
         self.minzoom = min(zoom[0] for zoom in zooms)
         self.maxzoom = max(zoom[1] for zoom in zooms)
 
@@ -141,14 +135,59 @@ class XarrayMosaicBackend(BaseBackend):
             **kwargs,
         )
 
+    @staticmethod
+    def _longitude_intervals(
+        west: float, east: float
+    ) -> tuple[tuple[float, float], ...]:
+        """Split a WGS84 longitude range at the antimeridian when needed."""
+        return ((west, east),) if west <= east else ((west, 180), (-180, east))
+
+    def _mosaic_bounds(self) -> BBox:
+        """Return the smallest WGS84 bounding box containing every asset."""
+        intervals = sorted(
+            interval
+            for bounds in self._asset_bounds
+            for interval in self._longitude_intervals(bounds[0], bounds[2])
+        )
+        merged: list[tuple[float, float]] = []
+        for west, east in intervals:
+            if merged and west <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], east))
+            else:
+                merged.append((west, east))
+
+        if merged == [(-180, 180)]:
+            west, east = -180, 180
+        else:
+            _, west, east = max(
+                (
+                    ((next_west - current_east) % 360, next_west, current_east)
+                    for (_, current_east), (next_west, _) in zip(
+                        merged, merged[1:] + merged[:1]
+                    )
+                ),
+                key=lambda gap: gap[0],
+            )
+
+        return (
+            west,
+            min(bounds[1] for bounds in self._asset_bounds),
+            east,
+            max(bounds[3] for bounds in self._asset_bounds),
+        )
+
     def _assets_for_bounds(self, query_bounds: BBox) -> list[str]:
         """Filter cached WGS84 bounds without changing input order."""
         xmin, ymin, xmax, ymax = query_bounds
+        query_longitudes = self._longitude_intervals(xmin, xmax)
         return [
             asset
             for asset, bounds in zip(self.input, self._asset_bounds)
-            if bounds[0] <= xmax
-            and bounds[2] >= xmin
-            and bounds[1] <= ymax
+            if bounds[1] <= ymax
             and bounds[3] >= ymin
+            and any(
+                west <= query_east and east >= query_west
+                for west, east in self._longitude_intervals(bounds[0], bounds[2])
+                for query_west, query_east in query_longitudes
+            )
         ]

--- a/src/titiler/multidim/mosaic.py
+++ b/src/titiler/multidim/mosaic.py
@@ -1,0 +1,154 @@
+"""Request-scoped Xarray mosaic backend."""
+
+from typing import Any
+
+import attr
+from morecantile import Tile
+from rasterio.crs import CRS
+from rasterio.warp import transform, transform_bounds
+from rio_tiler.constants import WGS84_CRS
+from rio_tiler.errors import NoAssetFoundError, PointOutsideBounds
+from rio_tiler.mosaic.backend import BaseBackend
+from rio_tiler.mosaic.reader import mosaic_point_reader
+from rio_tiler.types import BBox
+from rio_tiler.utils import inherit_rasterio_env
+from titiler.core.errors import BadRequestError
+
+
+@attr.s
+class XarrayMosaicBackend(BaseBackend):
+    """Mosaic a request-ordered list of compatible Xarray datasets."""
+
+    _asset_bounds: list[BBox] = attr.ib(init=False, factory=list)
+    _asset_info: list[dict[str, Any]] = attr.ib(init=False, factory=list)
+
+    def __attrs_post_init__(self) -> None:
+        """Validate every requested source and collect its geographic metadata."""
+        if not 1 <= len(self.input) <= 20:
+            raise BadRequestError("Provide between one and twenty url parameters.")
+
+        signature: tuple[Any, ...] | None = None
+        zooms: list[tuple[int, int]] = []
+        for asset in self.input:
+            with self.reader(asset, tms=self.tms, **self.reader_options) as src:
+                info = src.info().model_dump()
+                current = (
+                    str(src.input.dtype),
+                    src.input.rio.count,
+                    tuple(
+                        dimension
+                        for dimension in src.input.dims
+                        if dimension not in {src.input.rio.x_dim, src.input.rio.y_dim}
+                    ),
+                    tuple(src.band_descriptions),
+                    repr(info["band_metadata"]),
+                    info["nodata_type"],
+                )
+                if signature is not None and current != signature:
+                    raise BadRequestError("Requested Xarray sources are incompatible.")
+
+                signature = current
+                self._asset_bounds.append(src.get_geographic_bounds(WGS84_CRS))
+                self._asset_info.append(info)
+                zooms.append((src.minzoom, src.maxzoom))
+
+        self.crs = WGS84_CRS
+        self.bounds = (
+            min(bounds[0] for bounds in self._asset_bounds),
+            min(bounds[1] for bounds in self._asset_bounds),
+            max(bounds[2] for bounds in self._asset_bounds),
+            max(bounds[3] for bounds in self._asset_bounds),
+        )
+        self.minzoom = min(zoom[0] for zoom in zooms)
+        self.maxzoom = max(zoom[1] for zoom in zooms)
+
+    def info(self) -> dict[str, Any]:
+        """Return native metadata for one source or shared metadata for a mosaic."""
+        if len(self._asset_info) == 1:
+            return self._asset_info[0]
+
+        info = {
+            key: value
+            for key, value in self._asset_info[0].items()
+            if key not in {"bounds", "crs", "width", "height", "dimensions"}
+            and all(other.get(key) == value for other in self._asset_info[1:])
+        }
+        info.update(
+            bounds=self.bounds, crs="http://www.opengis.net/def/crs/EPSG/0/4326"
+        )
+        return info
+
+    def assets_for_tile(self, x: int, y: int, z: int, **kwargs: Any) -> list[str]:
+        """Return request-ordered assets intersecting a tile."""
+        return self._assets_for_bounds(self.tms.bounds(Tile(x, y, z)))
+
+    def assets_for_point(
+        self,
+        lng: float,
+        lat: float,
+        coord_crs: CRS | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Return request-ordered assets containing a point."""
+        if coord_crs and coord_crs != WGS84_CRS:
+            xs, ys = transform(coord_crs, WGS84_CRS, [lng], [lat])
+            lng, lat = xs[0], ys[0]
+        return self._assets_for_bounds((lng, lat, lng, lat))
+
+    def assets_for_bbox(
+        self,
+        xmin: float,
+        ymin: float,
+        xmax: float,
+        ymax: float,
+        coord_crs: CRS | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        """Return request-ordered assets intersecting a bounding box."""
+        if coord_crs and coord_crs != WGS84_CRS:
+            xmin, ymin, xmax, ymax = transform_bounds(
+                coord_crs, WGS84_CRS, xmin, ymin, xmax, ymax
+            )
+        return self._assets_for_bounds((xmin, ymin, xmax, ymax))
+
+    def point(
+        self,
+        lon: float,
+        lat: float,
+        coord_crs: CRS = WGS84_CRS,
+        search_options: dict | None = None,
+        **kwargs: Any,
+    ):
+        """Return one rio-tiler-composited point and its contributing assets."""
+        assets = self.assets_for_point(
+            lon, lat, coord_crs=coord_crs, **(search_options or {})
+        )
+        if not assets:
+            raise NoAssetFoundError(f"No assets found for point ({lon},{lat})")
+
+        @inherit_rasterio_env
+        def read_point(asset: str, *args: Any, **options: Any):
+            with self.reader(asset, **self.reader_options) as src:
+                return src.point(*args, **options)
+
+        return mosaic_point_reader(
+            assets,
+            read_point,
+            lon,
+            lat,
+            coord_crs=coord_crs,
+            allowed_exceptions=(PointOutsideBounds,),
+            **kwargs,
+        )
+
+    def _assets_for_bounds(self, query_bounds: BBox) -> list[str]:
+        """Filter cached WGS84 bounds without changing input order."""
+        xmin, ymin, xmax, ymax = query_bounds
+        return [
+            asset
+            for asset, bounds in zip(self.input, self._asset_bounds)
+            if bounds[0] <= xmax
+            and bounds[2] >= xmin
+            and bounds[1] <= ymax
+            and bounds[3] >= ymin
+        ]

--- a/src/titiler/multidim/reader.py
+++ b/src/titiler/multidim/reader.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import pickle
+import time
 from typing import (
     Any,
     Dict,
@@ -26,6 +28,12 @@ from titiler.multidim.settings import ApiSettings
 
 api_settings = ApiSettings()
 cache_client = get_redis()
+logger = logging.getLogger(__name__)
+
+
+def _log_path(src_path: str) -> str:
+    """Return a source path without a potentially sensitive query string."""
+    return src_path.split("?", maxsplit=1)[0]
 
 
 def opener_icechunk(
@@ -56,12 +64,22 @@ def opener_icechunk(
             f"icechunk storage for protocol {protocol} is not implemented"
         )
 
+    log_path = _log_path(src_path)
+    logger.info("Opening Icechunk repository: source=%s", log_path)
+    started_at = time.monotonic()
     repo = icechunk.Repository.open(
         storage=storage, authorize_virtual_chunk_access=credentials
     )
+    logger.info(
+        "Opened Icechunk repository: source=%s elapsed_seconds=%.2f",
+        log_path,
+        time.monotonic() - started_at,
+    )
     session = repo.readonly_session("main")
     store = session.store
-    return xr.open_dataset(
+    logger.info("Opening Icechunk dataset: source=%s group=%s", log_path, group)
+    started_at = time.monotonic()
+    dataset = xr.open_dataset(
         store,
         group=group,
         decode_times=decode_times,
@@ -69,6 +87,12 @@ def opener_icechunk(
         consolidated=False,
         zarr_format=3,
     )
+    logger.info(
+        "Opened Icechunk dataset: source=%s elapsed_seconds=%.2f",
+        log_path,
+        time.monotonic() - started_at,
+    )
+    return dataset
 
 
 # TODO Is there a better way to check if a url points to a file or a prefix?
@@ -76,6 +100,7 @@ def _is_dir(store, path: str = "") -> bool:
     """Return True if path is a prefix containing any objects (directory-like)."""
     # sanitize path and slashes
     path = path.rstrip("/") + "/"
+    logger.info("Checking dataset storage prefix: prefix=%s", path)
     stream = store.list(prefix=path, chunk_size=1)
     try:
         batch = next(stream)
@@ -138,7 +163,16 @@ def guess_opener(
     """
 
     # Identify the storage backend
+    log_path = _log_path(src_path)
+    logger.info("Identifying dataset storage: source=%s", log_path)
+    started_at = time.monotonic()
     storage_format = identify_storage_backend(src_path)
+    logger.info(
+        "Identified dataset storage: source=%s format=%s elapsed_seconds=%.2f",
+        log_path,
+        storage_format,
+        time.monotonic() - started_at,
+    )
 
     if storage_format == "icechunk":
         return opener_icechunk(
@@ -182,15 +216,31 @@ class XarrayReader(Reader):
             f"{src_path}_group:{kwargs.get('group')}_time:{kwargs.get('decode_times')}"
         )
 
+        log_path = _log_path(src_path)
         if api_settings.enable_cache:
+            logger.info("Reading dataset cache: source=%s", log_path)
+            started_at = time.monotonic()
             data_bytes = cache_client.get(cache_key)
+            logger.info(
+                "Read dataset cache: source=%s hit=%s elapsed_seconds=%.2f",
+                log_path,
+                bool(data_bytes),
+                time.monotonic() - started_at,
+            )
             if data_bytes:
                 return pickle.loads(data_bytes)
 
         ds = guess_opener(src_path, **kwargs)
 
         if api_settings.enable_cache:
+            logger.info("Writing dataset cache: source=%s", log_path)
+            started_at = time.monotonic()
             cache_client.set(cache_key, pickle.dumps(ds), ex=300)
+            logger.info(
+                "Wrote dataset cache: source=%s elapsed_seconds=%.2f",
+                log_path,
+                time.monotonic() - started_at,
+            )
 
         return ds
 

--- a/src/titiler/multidim/reader.py
+++ b/src/titiler/multidim/reader.py
@@ -75,6 +75,13 @@ def opener_icechunk(
         log_path,
         time.monotonic() - started_at,
     )
+    for prefix, container in (repo.config.virtual_chunk_containers or {}).items():
+        logger.info(
+            "Icechunk virtual chunk container: source=%s prefix=%s store=%s",
+            log_path,
+            prefix,
+            container.store,
+        )
     session = repo.readonly_session("main")
     store = session.store
     logger.info("Opening Icechunk dataset: source=%s group=%s", log_path, group)
@@ -208,7 +215,15 @@ class XarrayReader(Reader):
         """Configure the cached opener before the parent reads the dataset."""
         self.opener_options = _inject_settings(self.opener_options)
         self.opener = self._open_cached
+        log_path = _log_path(self.src_path)
+        logger.info("Initializing Xarray reader spatial metadata: source=%s", log_path)
+        started_at = time.monotonic()
         super().__attrs_post_init__()
+        logger.info(
+            "Initialized Xarray reader spatial metadata: source=%s elapsed_seconds=%.2f",
+            log_path,
+            time.monotonic() - started_at,
+        )
 
     def _open_cached(self, src_path: str, **kwargs: Any) -> xr.Dataset:
         """Open a dataset, reusing its Redis cache entry when enabled."""

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -28,11 +28,11 @@ def test_dataset_metadata_extension_uses_one_url(app):
 @pytest.mark.parametrize(
     "path", ["/dataset/", "/dataset/dict", "/dataset/keys", "/validate"]
 )
-def test_dataset_metadata_extension_rejects_multiple_urls(app, path):
-    """Dataset metadata routes do not invent multi-source metadata."""
-    response = app.get(
-        path,
-        params=[("url", "tests/fixtures/testfile.nc")] * 2,
+def test_dataset_metadata_extension_documents_a_single_url(app, path):
+    """Dataset metadata routes expose url as a scalar query parameter."""
+    parameters = app.get("/api").json()["paths"][path]["get"]["parameters"]
+    url_parameter = next(
+        parameter for parameter in parameters if parameter["name"] == "url"
     )
 
-    assert response.status_code == 422
+    assert url_parameter["schema"]["type"] == "string"

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,38 @@
+"""Custom extension tests."""
+
+import pytest
+
+
+def test_dataset_metadata_extension_uses_one_url(app):
+    """Dataset metadata routes accept one URL without raster parameters."""
+    params = {"url": "tests/fixtures/testfile.nc"}
+
+    keys = app.get("/dataset/keys", params=params)
+    metadata = app.get("/dataset/dict", params=params)
+    html = app.get("/dataset/", params=params)
+    validation = app.get("/validate", params=params)
+
+    assert keys.status_code == 200
+    assert keys.json() == ["data"]
+    assert metadata.status_code == 200
+    assert metadata.json()["data_vars"]["data"]
+    assert html.status_code == 200
+    assert validation.status_code == 200
+    assert validation.json()["data"].keys() == {
+        "compatible_with_titiler",
+        "errors",
+        "warnings",
+    }
+
+
+@pytest.mark.parametrize(
+    "path", ["/dataset/", "/dataset/dict", "/dataset/keys", "/validate"]
+)
+def test_dataset_metadata_extension_rejects_multiple_urls(app, path):
+    """Dataset metadata routes do not invent multi-source metadata."""
+    response = app.get(
+        path,
+        params=[("url", "tests/fixtures/testfile.nc")] * 2,
+    )
+
+    assert response.status_code == 422

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from rasterio.crs import CRS
 from obstore.exceptions import GenericError
 from rio_tiler.mosaic.methods.defaults import FirstMethod, HighestMethod
 from titiler.core.errors import BadRequestError
@@ -32,6 +33,36 @@ def write_dataset(path, value, *, x=(-5.0, 5.0), times=None, extra_variable=Fals
     dataset.to_netcdf(path, engine="h5netcdf")
 
 
+def write_antimeridian_dataset(path):
+    """Write a polar stereographic dataset that crosses the antimeridian."""
+    dataset = xr.Dataset(
+        {"data": (("y", "x"), np.ones((553, 825), dtype="float32"))},
+        coords={
+            "x": np.linspace(-2622372.468724773, 2288852.531275227, 825),
+            "y": np.linspace(-4813079.750943905, -1521070.7509439047, 553),
+        },
+    ).rio.write_crs(
+        CRS.from_proj4(
+            "+proj=stere +lat_0=90 +lat_ts=60 +lon_0=210 "
+            "+a=6371229 +b=6371229 +units=m +no_defs"
+        )
+    )
+    dataset.to_netcdf(path, engine="h5netcdf")
+
+
+def write_coordinate_labeled_dataset(path, label):
+    """Write a geographic dataset with an auxiliary display coordinate."""
+    dataset = xr.Dataset(
+        {"data": (("y", "x"), np.ones((2, 2), dtype="float32"))},
+        coords={
+            "x": [-5.0, 5.0],
+            "y": [-5.0, 5.0],
+            "label": (("y", "x"), np.full((2, 2), label)),
+        },
+    ).rio.write_crs("EPSG:4326")
+    dataset.to_netcdf(path, engine="h5netcdf")
+
+
 @pytest.fixture
 def sources(tmp_path):
     """Create compatible adjacent and overlapping Xarray sources."""
@@ -57,6 +88,47 @@ def test_backend_filters_assets_in_request_order(sources, reader_cls):
 
     assert backend.assets_for_bbox(-6, -1, 6, 1) == [str(left), str(right)]
     assert backend.assets_for_point(5, 0) == [str(right)]
+
+
+def test_backend_selects_antimeridian_crossing_assets(tmp_path, reader_cls):
+    """Antimeridian-crossing source bounds include points on both sides."""
+    source = tmp_path / "antimeridian.nc"
+    write_antimeridian_dataset(source)
+    backend = XarrayMosaicBackend(
+        [str(source)], reader=reader_cls, reader_options={"variable": "data"}
+    )
+
+    assert backend.assets_for_point(170, 60) == [str(source)]
+    assert backend.assets_for_point(-150, 60) == [str(source)]
+
+
+def test_backend_reports_antimeridian_crossing_mosaic_bounds(sources, reader_cls):
+    """Adjacent sources across the antimeridian retain wrapped bounds."""
+    west, east, _, _ = sources
+    write_dataset(west, 1, x=(172.5, 177.5))
+    write_dataset(east, 2, x=(-177.5, -172.5))
+
+    backend = XarrayMosaicBackend(
+        [str(west), str(east)], reader=reader_cls, reader_options={"variable": "data"}
+    )
+
+    assert backend.bounds == (170.0, -10.0, -170.0, 10.0)
+
+
+def test_backend_ignores_auxiliary_coordinate_labels(tmp_path, reader_cls):
+    """Auxiliary coordinates do not make compatible sources incompatible."""
+    first = tmp_path / "first.nc"
+    second = tmp_path / "second.nc"
+    write_coordinate_labeled_dataset(first, 1)
+    write_coordinate_labeled_dataset(second, 2)
+
+    backend = XarrayMosaicBackend(
+        [str(first), str(second)],
+        reader=reader_cls,
+        reader_options={"variable": "data"},
+    )
+
+    assert backend.assets_for_point(0, 0) == [str(first), str(second)]
 
 
 def test_backend_composes_points_with_requested_strategy(sources, reader_cls):

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,0 +1,165 @@
+"""Xarray mosaic behavior."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from obstore.exceptions import GenericError
+from rio_tiler.mosaic.methods.defaults import FirstMethod, HighestMethod
+from titiler.core.errors import BadRequestError
+
+from titiler.multidim.mosaic import XarrayMosaicBackend
+
+
+@pytest.fixture
+def reader_cls(monkeypatch):
+    """Return the current reader class with its Redis cache disabled."""
+    from titiler.multidim import reader
+
+    monkeypatch.setattr(reader.api_settings, "enable_cache", False)
+    return reader.XarrayReader
+
+
+def write_dataset(path, value, *, x=(-5.0, 5.0), times=None, extra_variable=False):
+    """Write a small geographic NetCDF dataset with a known value."""
+    times = times or [0]
+    data = np.full((len(times), 2, 2), value, dtype="float32")
+    dataset = xr.Dataset(
+        {"data": (("time", "lat", "lon"), data)},
+        coords={"time": times, "lat": [-5.0, 5.0], "lon": list(x)},
+    ).rio.write_crs("EPSG:4326")
+    if extra_variable:
+        dataset["other"] = dataset["data"]
+    dataset.to_netcdf(path, engine="h5netcdf")
+
+
+@pytest.fixture
+def sources(tmp_path):
+    """Create compatible adjacent and overlapping Xarray sources."""
+    left = tmp_path / "left.nc"
+    right = tmp_path / "right.nc"
+    first = tmp_path / "first.nc"
+    second = tmp_path / "second.nc"
+    write_dataset(left, 1, x=(-7.5, -2.5))
+    write_dataset(right, 2, x=(2.5, 7.5))
+    write_dataset(first, 1)
+    write_dataset(second, 2)
+    return left, right, first, second
+
+
+def test_backend_filters_assets_in_request_order(sources, reader_cls):
+    """Adjacent sources are filtered spatially without changing their priority."""
+    left, right, _, _ = sources
+    backend = XarrayMosaicBackend(
+        [str(left), str(right)],
+        reader=reader_cls,
+        reader_options={"variable": "data"},
+    )
+
+    assert backend.assets_for_bbox(-6, -1, 6, 1) == [str(left), str(right)]
+    assert backend.assets_for_point(5, 0) == [str(right)]
+
+
+def test_backend_composes_points_with_requested_strategy(sources, reader_cls):
+    """Point composition uses rio-tiler's first and highest methods."""
+    _, _, first, second = sources
+    backend = XarrayMosaicBackend(
+        [str(first), str(second)],
+        reader=reader_cls,
+        reader_options={"variable": "data"},
+    )
+
+    point, _ = backend.point(0, 0, pixel_selection=FirstMethod)
+    assert point.array.tolist() == [1.0]
+
+    point, _ = backend.point(0, 0, pixel_selection=HighestMethod)
+    assert point.array.tolist() == [2.0]
+
+    image, _ = backend.part(
+        (-10, -10, 10, 10), width=2, height=2, pixel_selection=HighestMethod
+    )
+    assert image.array.compressed().tolist() == [2.0] * 4
+
+
+def test_backend_rejects_unreadable_and_incompatible_sources(
+    sources, tmp_path, reader_cls
+):
+    """Construction validates every requested source before it can be mosaicked."""
+    left, _, _, _ = sources
+    incompatible = tmp_path / "incompatible.nc"
+    write_dataset(incompatible, 2, times=[0, 1])
+
+    with pytest.raises(GenericError):
+        XarrayMosaicBackend(
+            [str(left), str(tmp_path / "missing.nc")],
+            reader=reader_cls,
+            reader_options={"variable": "data"},
+        )
+
+    with pytest.raises(BadRequestError):
+        XarrayMosaicBackend(
+            [str(left), str(incompatible)],
+            reader=reader_cls,
+            reader_options={"variable": "data"},
+        )
+
+
+def test_mosaic_endpoints_preserve_shapes_and_compose_data(app, sources):
+    """Multiple URLs retain Xarray responses while reporting aggregate coverage."""
+    left, right, first, second = sources
+    adjacent = [("url", str(left)), ("url", str(right)), ("variable", "data")]
+
+    info = app.get("/info", params=adjacent)
+    assert info.status_code == 200
+    assert info.json()["bounds"] == [-10.0, -10.0, 10.0, 10.0]
+    assert "width" not in info.json()
+    assert "height" not in info.json()
+
+    point = app.get(
+        "/point/0,0",
+        params=[("url", str(first)), ("url", str(second)), ("variable", "data")],
+    )
+    assert point.status_code == 200
+    assert point.json()["values"] == [1.0]
+
+    highest = app.get(
+        "/point/0,0",
+        params=[
+            ("url", str(first)),
+            ("url", str(second)),
+            ("variable", "data"),
+            ("pixel_selection", "highest"),
+        ],
+    )
+    assert highest.status_code == 200
+    assert highest.json()["values"] == [2.0]
+
+    histogram = app.get(
+        "/histogram",
+        params=[
+            ("url", str(first)),
+            ("url", str(second)),
+            ("variable", "data"),
+            ("pixel_selection", "highest"),
+        ],
+    )
+    assert histogram.status_code == 200
+    assert histogram.json()[0]["bucket"][0] == 1.5
+
+
+def test_mosaic_url_limits_and_variable_mismatch(app, sources, tmp_path):
+    """The API validates URL cardinality and common variable namespaces."""
+    left, _, _, _ = sources
+    mismatched = tmp_path / "mismatched.nc"
+    write_dataset(mismatched, 2, extra_variable=True)
+
+    assert app.get("/info", params={"variable": "data"}).status_code == 422
+    assert (
+        app.get(
+            "/info",
+            params=[("url", str(left))] * 21 + [("variable", "data")],
+        ).status_code
+        == 422
+    )
+    assert (
+        app.get("/variables", params=[("url", str(left)), ("url", str(mismatched))])
+    ).status_code == 400

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -218,6 +218,17 @@ def test_mosaic_endpoints_preserve_shapes_and_compose_data(app, sources):
     assert histogram.json()[0]["bucket"][0] == 1.5
 
 
+def test_tile_outside_mosaic_returns_no_content(app, sources):
+    """A tile outside all requested sources returns no content."""
+    left, right, _, _ = sources
+    response = app.get(
+        "/tiles/WebMercatorQuad/2/0/0.png",
+        params=[("url", str(left)), ("url", str(right)), ("variable", "data")],
+    )
+
+    assert response.status_code == 204
+
+
 def test_mosaic_url_limits_and_variable_mismatch(app, sources, tmp_path):
     """The API validates URL cardinality and common variable namespaces."""
     left, _, _, _ = sources
@@ -235,7 +246,6 @@ def test_mosaic_url_limits_and_variable_mismatch(app, sources, tmp_path):
     assert (
         app.get("/variables", params=[("url", str(left)), ("url", str(mismatched))])
     ).status_code == 400
-
 
 
 def test_histogram_supports_antimeridian_sources(app, tmp_path):

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -235,3 +235,33 @@ def test_mosaic_url_limits_and_variable_mismatch(app, sources, tmp_path):
     assert (
         app.get("/variables", params=[("url", str(left)), ("url", str(mismatched))])
     ).status_code == 400
+
+
+
+def test_histogram_supports_antimeridian_sources(app, tmp_path):
+    """Histogram pools values from both sides of the antimeridian."""
+    west = tmp_path / "am-west.nc"
+    east = tmp_path / "am-east.nc"
+    write_dataset(west, 1, x=(172.5, 177.5))
+    write_dataset(east, 2, x=(-177.5, -172.5))
+
+    response = app.get(
+        "/histogram",
+        params=[("url", str(west)), ("url", str(east)), ("variable", "data")],
+    )
+    assert response.status_code == 200
+    histogram = response.json()
+    assert sum(bucket["value"] for bucket in histogram) > 0
+    assert histogram[0]["bucket"][0] == 1.0
+    assert histogram[-1]["bucket"][1] == 2.0
+
+    projected = tmp_path / "am-projected.nc"
+    write_antimeridian_dataset(projected)
+    response = app.get(
+        "/histogram", params=[("url", str(projected)), ("variable", "data")]
+    )
+    assert response.status_code == 200
+    histogram = response.json()
+    assert sum(bucket["value"] for bucket in histogram) > 0
+    assert histogram[0]["bucket"][0] == 0.5
+    assert histogram[-1]["bucket"][1] == 1.5

--- a/uv.lock
+++ b/uv.lock
@@ -2195,22 +2195,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-httpx"
-version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/27/c2b4335bca030e893acbe5ff2b4f434868773bf94508be7e6bf5af981b24/opentelemetry_instrumentation_httpx-0.63b1.tar.gz", hash = "sha256:f41ec82f25c3abcdada621052db3e5fd648e3b43d55eec4b9c0c5d3ecb7b4ff4", size = 23557, upload-time = "2026-05-21T16:36:34.583Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/b8/f536780996195c3b9f2354998554671e05a7a262df8c043f63fe9e5a6f0b/opentelemetry_instrumentation_httpx-0.63b1-py3-none-any.whl", hash = "sha256:14df6e99d81be9a8cd238f6639b6fa52404c4d3ce219058fcb5dc8c0f2211f86", size = 16336, upload-time = "2026-05-21T16:35:32.221Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation-logging"
 version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
@@ -3396,7 +3380,6 @@ lambda = [
     { name = "mangum" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
-    { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-propagator-aws-xray" },
     { name = "opentelemetry-sdk" },
@@ -3453,7 +3436,6 @@ requires-dist = [
     { name = "obstore", specifier = ">=0.9.4" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'lambda'", specifier = ">=1.40.0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'lambda'", specifier = ">=0.61b0" },
-    { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'lambda'", specifier = ">=0.61b0" },
     { name = "opentelemetry-instrumentation-logging", marker = "extra == 'lambda'", specifier = ">=0.61b0" },
     { name = "opentelemetry-propagator-aws-xray", marker = "extra == 'lambda'", specifier = ">=1.0.2" },
     { name = "opentelemetry-sdk", marker = "extra == 'lambda'", specifier = ">=1.40.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1177,6 +1177,49 @@ wheels = [
 ]
 
 [[package]]
+name = "gribberish"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/82/235485420d78041a0061f09d69ab552a7eb3d7ae0ace6c9746e60e5953e1/gribberish-1.7.0.tar.gz", hash = "sha256:637f5565983d3a5b8a3b7fbee5af7edaaf177124856903a76298eebb9ed98c0f", size = 3286022, upload-time = "2026-08-13T18:13:46.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/81/a26093776d9c9efbce42e5e95b66bfd282560dcb9d606416271f95c4243d/gribberish-1.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e1840c2f68e055b3efa3ccc5ec9485aaeb927b9e27ba492cac864d0137db054c", size = 787002, upload-time = "2026-08-13T18:13:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/00b41c7aea2baa498b7c22d8bbd0b92e96c8c181dd17d5b50759948da03f/gribberish-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6ddb80d021ff373e0fcd5d29ea7aab0a589e5b0c6f4adec02439618cbce9bcc2", size = 726967, upload-time = "2026-08-13T18:13:14.476Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/1998468b05f32fa93e0e3d2f03688dda182933f4a13fd5f233a39e2d1581/gribberish-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a21531a0d6b9d78b56853575419a7bbf1ff8a2bce73552230ea8933cebc27098", size = 766260, upload-time = "2026-08-13T18:12:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e1/80e2ee2ce2ef1a7f58f443d186bfc0e093794b92938563464611afcc0f0f/gribberish-1.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:30295947fb86f82a3b4e034d24940361fc164fc7104729b481f2298cdd036e54", size = 790320, upload-time = "2026-08-13T18:13:01.489Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4d/ef5f1046baf29bd2f10d5cb6eac4b803cb38492cfa2fcf5ffc763003237a/gribberish-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1011eba4ed604b782b28f6b1d18982a0d9241dbcb53bde5b7aaa6fea6d9eefc0", size = 821591, upload-time = "2026-08-13T18:13:08.257Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ac/b42c17212d7db978882eb6f319f89379a314f90fddab273fa4b59ae06e81/gribberish-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9d1277a56ff7aaeb1938d41c6741fa9ebae520904af53d92cd9bbdeebe0dd844", size = 951801, upload-time = "2026-08-13T18:13:27.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3f/97e899fc44405a60af0fb79ec81bd5412dbc9d81ad4118956b640e7a0d40/gribberish-1.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:36bbb339ff1612ee1b360a859aff4f490120a4265b2c13ee3245e1bd28bdfaea", size = 1069191, upload-time = "2026-08-13T18:13:33.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/44/730d5eebf65d44313ed98d14025898e751ab47a5782ff0985c11e22b015b/gribberish-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f448031880b92df8e7681cccdfd5b3c78bfe2fb869f9c04539d0c680a53afa84", size = 1037617, upload-time = "2026-08-13T18:13:40.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/76/f50cc49ab0dd06e6fa998b7b1652cc4f35495e5dee45010d70bda79854ed/gribberish-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b37b272928bcf0b984cfb884c06953203b0e536d94e9233fc021aa007cf08bb", size = 718001, upload-time = "2026-08-13T18:13:49.225Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ed/063edf0f79e7b55263f25d7a125ae1da341157795275a6692f4a9454ea0e/gribberish-1.7.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:16cf0e68edd8b6d299a9678145c4e0bd501095eb8a52964e125cc2bdafd940cf", size = 786910, upload-time = "2026-08-13T18:13:22.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/9ea308092be946f948867c592e17fc3692308cdc2ea87a0c8d000b50b01f/gribberish-1.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d154c4418ad4a55c02f52f6ddd595158183ee7cfd71f32e7d003648e3e7cb689", size = 726794, upload-time = "2026-08-13T18:13:15.878Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/48a9e2c42cb757d57ad8414488f005887279d91bfd1e75b0ab9d286a859b/gribberish-1.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e5e4c9c682b0eeb982ee47b947d813ab49cdd405aa078d5e138171a88c6f63", size = 766247, upload-time = "2026-08-13T18:12:56.394Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b1/31da4fc5de0b11ec40eb347fcca8523a0457400ad5eec415f9db644f4c21/gribberish-1.7.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b358d5d0b637f2561ac8f5f368860af6a69c6d49b0ebcb0ee3b66e69427310", size = 789838, upload-time = "2026-08-13T18:13:02.872Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/24/4dd8476c4614a15e15205ddb6d6b5fa8d558fd5d8d287da0ca201f81e972/gribberish-1.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:349f2f12f106c731a678aad94f35a9603b3f403c30ea6c1315dab4623004aa8e", size = 821077, upload-time = "2026-08-13T18:13:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/21/d23d70bde7833282ccb157a5bebf7768a9c08c768e58539f3d66e72d6df3/gribberish-1.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e988a8a491bbe74c7e17a195742eb2bec1c2bb58512e0835320d06c732cffb73", size = 951532, upload-time = "2026-08-13T18:13:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/83/3497ee042178fa9dbe1d39da687b30bc89020de9cd1d92a0faa13f9b88bb/gribberish-1.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:747219c1706073a344904c80c11e3f42ffb848979cacd77901f0997648e57d12", size = 1068855, upload-time = "2026-08-13T18:13:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/eb/a48c7372227d511d664ab77db2239ed15e95c5685f80cdaca8633d39fb86/gribberish-1.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b40e7f67cfe603a5072545e87ff3b5cdb5b61a5950ff0e827aef931cf5c51542", size = 1037502, upload-time = "2026-08-13T18:13:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a8/1b6cd48fb2c3cb8b05585d4e1a402ee3794f883cffdf6f72815c997323da/gribberish-1.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:10a7ff2e3a286435bf7cf37a66895c65b47588fe8cd1394f0c2ddd69978063c3", size = 717787, upload-time = "2026-08-13T18:13:50.396Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/0f65b889800d89c17a8fdf15dc6566234da74c6e71ccd3e2367cfa366956/gribberish-1.7.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1031c25eb6254b6cce99d8e1d47bb24bd5ed53067c1a1113e0c489c46382ed9e", size = 787877, upload-time = "2026-08-13T18:13:23.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ea/3a39094f5f4845b79dc17d84d6667d0cff0a6debaefb80d2552a9eeca1ac/gribberish-1.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5848eb602fd304c25c901d606ce15f9dfebf673572d24bd1f2e4f2d261410114", size = 726471, upload-time = "2026-08-13T18:13:17.047Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6c/e8be1d377d84fd3974ff3b4848c4404cc7f137a102c3b01e1176da44c3ce/gribberish-1.7.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb889c53c2796fdb15a67d8e649f1f613993c11cd1ed4b40712712490078c3c", size = 765493, upload-time = "2026-08-13T18:12:57.798Z" },
+    { url = "https://files.pythonhosted.org/packages/58/08/2c23fbf1fa3d6a2b2b4e8ff050c2b40edc038a9de81fde200962cdf5bf7b/gribberish-1.7.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad0acda84f66f52be3261466b399147443c4ffee6aa790bfa5529c7a0e74ac0b", size = 789707, upload-time = "2026-08-13T18:13:04.123Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/82/05054de06c9b2cb864633d9c1a71f6bac0a9f5fcfa38d5cc79fe3f065795/gribberish-1.7.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5291b134a17d2e63d3346e39f6cff60429c05af19d2d62b904aa0e956a83b60b", size = 820435, upload-time = "2026-08-13T18:13:10.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4c/6df5d5dca2eab36fe44d3bbe0f3b35634b07a0664943ef80b9ae105c36cf/gribberish-1.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:979010bba9a20a2adf3afcab252d899670c32d252f5a88d82cfcd38dda9f152d", size = 950797, upload-time = "2026-08-13T18:13:29.537Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9e/ec5eb580c1abf2a9fc60e08dc74defe8886ea5369f4defe68b0104d90f89/gribberish-1.7.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:84a3d6fcf0474ac9f680cddeee9e1da7c764cb93fe2d2282d0252cca3756cfce", size = 1068692, upload-time = "2026-08-13T18:13:36.763Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/906f193359d8ce869722d84cb47dbae5a20461d33d5cd4fda2064d24af14/gribberish-1.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:310d9674fd9a522014f569c30a9fbb39d4ed400c3497f99fcb8a5ba2fcb6d7e3", size = 1036557, upload-time = "2026-08-13T18:13:43.163Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8f/aaa26d60627611910aa3399de1c460ae1a493b7596c74817eb9bf209903b/gribberish-1.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7a4cb1c1498b65a3fa7c295a89b9693ac7d322e10b53a7d26c4ca2bcd596b795", size = 717657, upload-time = "2026-08-13T18:13:51.646Z" },
+]
+
+[package.optional-dependencies]
+zarr = [
+    { name = "zarr" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3311,6 +3354,18 @@ wheels = [
 ]
 
 [[package]]
+name = "titiler-mosaic"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "titiler-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5a/cc85707662366933e97a11994776e65bc17ad34f0306107afc55f8e6680f/titiler_mosaic-2.2.1.tar.gz", hash = "sha256:fccf7f502585b8584dd900e4db92f46be8594aea8cc47cfa56309b0c919eb3ec", size = 15466, upload-time = "2026-07-29T16:03:24.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/65/1d52eb7c0eca189feffd2a4787e231743f775e6fe4fc29b36e57f2a9b710/titiler_mosaic-2.2.1-py3-none-any.whl", hash = "sha256:4e27630e6d5e3e3485faf8197ae7b5e064d540e0636a40dd4e8adb783c363ef0", size = 18119, upload-time = "2026-07-29T16:03:18.638Z" },
+]
+
+[[package]]
 name = "titiler-multidim"
 source = { editable = "." }
 dependencies = [
@@ -3320,6 +3375,7 @@ dependencies = [
     { name = "cftime" },
     { name = "fastapi" },
     { name = "fsspec" },
+    { name = "gribberish", extra = ["zarr"] },
     { name = "h5netcdf" },
     { name = "h5py" },
     { name = "icechunk" },
@@ -3332,6 +3388,7 @@ dependencies = [
     { name = "rioxarray" },
     { name = "s3fs" },
     { name = "titiler-core" },
+    { name = "titiler-mosaic" },
     { name = "titiler-xarray" },
     { name = "xarray" },
     { name = "zarr" },
@@ -3391,6 +3448,7 @@ requires-dist = [
     { name = "cftime" },
     { name = "fastapi" },
     { name = "fsspec" },
+    { name = "gribberish", extras = ["zarr"], specifier = ">=1.7.0" },
     { name = "h5netcdf" },
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "icechunk", specifier = ">=2.1,<3" },
@@ -3411,6 +3469,7 @@ requires-dist = [
     { name = "rioxarray" },
     { name = "s3fs" },
     { name = "titiler-core", specifier = ">=2.2.1,<3.0" },
+    { name = "titiler-mosaic", specifier = "==2.2.1" },
     { name = "titiler-xarray", specifier = ">=2.2.1,<3.0" },
     { name = "uvicorn", marker = "extra == 'server'" },
     { name = "xarray", specifier = ">=2025.10.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -12,10 +12,6 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P1W"
-
 [[package]]
 name = "affine"
 version = "2.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1173,6 +1173,49 @@ wheels = [
 ]
 
 [[package]]
+name = "gribberish"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/82/235485420d78041a0061f09d69ab552a7eb3d7ae0ace6c9746e60e5953e1/gribberish-1.7.0.tar.gz", hash = "sha256:637f5565983d3a5b8a3b7fbee5af7edaaf177124856903a76298eebb9ed98c0f", size = 3286022, upload-time = "2026-08-13T18:13:46.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/81/a26093776d9c9efbce42e5e95b66bfd282560dcb9d606416271f95c4243d/gribberish-1.7.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e1840c2f68e055b3efa3ccc5ec9485aaeb927b9e27ba492cac864d0137db054c", size = 787002, upload-time = "2026-08-13T18:13:20.901Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/00b41c7aea2baa498b7c22d8bbd0b92e96c8c181dd17d5b50759948da03f/gribberish-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6ddb80d021ff373e0fcd5d29ea7aab0a589e5b0c6f4adec02439618cbce9bcc2", size = 726967, upload-time = "2026-08-13T18:13:14.476Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/1998468b05f32fa93e0e3d2f03688dda182933f4a13fd5f233a39e2d1581/gribberish-1.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a21531a0d6b9d78b56853575419a7bbf1ff8a2bce73552230ea8933cebc27098", size = 766260, upload-time = "2026-08-13T18:12:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e1/80e2ee2ce2ef1a7f58f443d186bfc0e093794b92938563464611afcc0f0f/gribberish-1.7.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:30295947fb86f82a3b4e034d24940361fc164fc7104729b481f2298cdd036e54", size = 790320, upload-time = "2026-08-13T18:13:01.489Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4d/ef5f1046baf29bd2f10d5cb6eac4b803cb38492cfa2fcf5ffc763003237a/gribberish-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1011eba4ed604b782b28f6b1d18982a0d9241dbcb53bde5b7aaa6fea6d9eefc0", size = 821591, upload-time = "2026-08-13T18:13:08.257Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ac/b42c17212d7db978882eb6f319f89379a314f90fddab273fa4b59ae06e81/gribberish-1.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9d1277a56ff7aaeb1938d41c6741fa9ebae520904af53d92cd9bbdeebe0dd844", size = 951801, upload-time = "2026-08-13T18:13:27.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3f/97e899fc44405a60af0fb79ec81bd5412dbc9d81ad4118956b640e7a0d40/gribberish-1.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:36bbb339ff1612ee1b360a859aff4f490120a4265b2c13ee3245e1bd28bdfaea", size = 1069191, upload-time = "2026-08-13T18:13:33.629Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/44/730d5eebf65d44313ed98d14025898e751ab47a5782ff0985c11e22b015b/gribberish-1.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f448031880b92df8e7681cccdfd5b3c78bfe2fb869f9c04539d0c680a53afa84", size = 1037617, upload-time = "2026-08-13T18:13:40.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/76/f50cc49ab0dd06e6fa998b7b1652cc4f35495e5dee45010d70bda79854ed/gribberish-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b37b272928bcf0b984cfb884c06953203b0e536d94e9233fc021aa007cf08bb", size = 718001, upload-time = "2026-08-13T18:13:49.225Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ed/063edf0f79e7b55263f25d7a125ae1da341157795275a6692f4a9454ea0e/gribberish-1.7.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:16cf0e68edd8b6d299a9678145c4e0bd501095eb8a52964e125cc2bdafd940cf", size = 786910, upload-time = "2026-08-13T18:13:22.077Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/9ea308092be946f948867c592e17fc3692308cdc2ea87a0c8d000b50b01f/gribberish-1.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d154c4418ad4a55c02f52f6ddd595158183ee7cfd71f32e7d003648e3e7cb689", size = 726794, upload-time = "2026-08-13T18:13:15.878Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/48a9e2c42cb757d57ad8414488f005887279d91bfd1e75b0ab9d286a859b/gribberish-1.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e5e4c9c682b0eeb982ee47b947d813ab49cdd405aa078d5e138171a88c6f63", size = 766247, upload-time = "2026-08-13T18:12:56.394Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b1/31da4fc5de0b11ec40eb347fcca8523a0457400ad5eec415f9db644f4c21/gribberish-1.7.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b358d5d0b637f2561ac8f5f368860af6a69c6d49b0ebcb0ee3b66e69427310", size = 789838, upload-time = "2026-08-13T18:13:02.872Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/24/4dd8476c4614a15e15205ddb6d6b5fa8d558fd5d8d287da0ca201f81e972/gribberish-1.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:349f2f12f106c731a678aad94f35a9603b3f403c30ea6c1315dab4623004aa8e", size = 821077, upload-time = "2026-08-13T18:13:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/21/d23d70bde7833282ccb157a5bebf7768a9c08c768e58539f3d66e72d6df3/gribberish-1.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e988a8a491bbe74c7e17a195742eb2bec1c2bb58512e0835320d06c732cffb73", size = 951532, upload-time = "2026-08-13T18:13:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/83/3497ee042178fa9dbe1d39da687b30bc89020de9cd1d92a0faa13f9b88bb/gribberish-1.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:747219c1706073a344904c80c11e3f42ffb848979cacd77901f0997648e57d12", size = 1068855, upload-time = "2026-08-13T18:13:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/eb/a48c7372227d511d664ab77db2239ed15e95c5685f80cdaca8633d39fb86/gribberish-1.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b40e7f67cfe603a5072545e87ff3b5cdb5b61a5950ff0e827aef931cf5c51542", size = 1037502, upload-time = "2026-08-13T18:13:41.843Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a8/1b6cd48fb2c3cb8b05585d4e1a402ee3794f883cffdf6f72815c997323da/gribberish-1.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:10a7ff2e3a286435bf7cf37a66895c65b47588fe8cd1394f0c2ddd69978063c3", size = 717787, upload-time = "2026-08-13T18:13:50.396Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0c/0f65b889800d89c17a8fdf15dc6566234da74c6e71ccd3e2367cfa366956/gribberish-1.7.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1031c25eb6254b6cce99d8e1d47bb24bd5ed53067c1a1113e0c489c46382ed9e", size = 787877, upload-time = "2026-08-13T18:13:23.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ea/3a39094f5f4845b79dc17d84d6667d0cff0a6debaefb80d2552a9eeca1ac/gribberish-1.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5848eb602fd304c25c901d606ce15f9dfebf673572d24bd1f2e4f2d261410114", size = 726471, upload-time = "2026-08-13T18:13:17.047Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6c/e8be1d377d84fd3974ff3b4848c4404cc7f137a102c3b01e1176da44c3ce/gribberish-1.7.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edb889c53c2796fdb15a67d8e649f1f613993c11cd1ed4b40712712490078c3c", size = 765493, upload-time = "2026-08-13T18:12:57.798Z" },
+    { url = "https://files.pythonhosted.org/packages/58/08/2c23fbf1fa3d6a2b2b4e8ff050c2b40edc038a9de81fde200962cdf5bf7b/gribberish-1.7.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad0acda84f66f52be3261466b399147443c4ffee6aa790bfa5529c7a0e74ac0b", size = 789707, upload-time = "2026-08-13T18:13:04.123Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/82/05054de06c9b2cb864633d9c1a71f6bac0a9f5fcfa38d5cc79fe3f065795/gribberish-1.7.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5291b134a17d2e63d3346e39f6cff60429c05af19d2d62b904aa0e956a83b60b", size = 820435, upload-time = "2026-08-13T18:13:10.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4c/6df5d5dca2eab36fe44d3bbe0f3b35634b07a0664943ef80b9ae105c36cf/gribberish-1.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:979010bba9a20a2adf3afcab252d899670c32d252f5a88d82cfcd38dda9f152d", size = 950797, upload-time = "2026-08-13T18:13:29.537Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9e/ec5eb580c1abf2a9fc60e08dc74defe8886ea5369f4defe68b0104d90f89/gribberish-1.7.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:84a3d6fcf0474ac9f680cddeee9e1da7c764cb93fe2d2282d0252cca3756cfce", size = 1068692, upload-time = "2026-08-13T18:13:36.763Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/906f193359d8ce869722d84cb47dbae5a20461d33d5cd4fda2064d24af14/gribberish-1.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:310d9674fd9a522014f569c30a9fbb39d4ed400c3497f99fcb8a5ba2fcb6d7e3", size = 1036557, upload-time = "2026-08-13T18:13:43.163Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8f/aaa26d60627611910aa3399de1c460ae1a493b7596c74817eb9bf209903b/gribberish-1.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:7a4cb1c1498b65a3fa7c295a89b9693ac7d322e10b53a7d26c4ca2bcd596b795", size = 717657, upload-time = "2026-08-13T18:13:51.646Z" },
+]
+
+[package.optional-dependencies]
+zarr = [
+    { name = "zarr" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3330,6 +3373,18 @@ wheels = [
 ]
 
 [[package]]
+name = "titiler-mosaic"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "titiler-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5a/cc85707662366933e97a11994776e65bc17ad34f0306107afc55f8e6680f/titiler_mosaic-2.2.1.tar.gz", hash = "sha256:fccf7f502585b8584dd900e4db92f46be8594aea8cc47cfa56309b0c919eb3ec", size = 15466, upload-time = "2026-07-29T16:03:24.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/65/1d52eb7c0eca189feffd2a4787e231743f775e6fe4fc29b36e57f2a9b710/titiler_mosaic-2.2.1-py3-none-any.whl", hash = "sha256:4e27630e6d5e3e3485faf8197ae7b5e064d540e0636a40dd4e8adb783c363ef0", size = 18119, upload-time = "2026-07-29T16:03:18.638Z" },
+]
+
+[[package]]
 name = "titiler-multidim"
 source = { editable = "." }
 dependencies = [
@@ -3339,6 +3394,7 @@ dependencies = [
     { name = "cftime" },
     { name = "fastapi" },
     { name = "fsspec" },
+    { name = "gribberish", extra = ["zarr"] },
     { name = "h5netcdf" },
     { name = "h5py" },
     { name = "icechunk" },
@@ -3351,6 +3407,7 @@ dependencies = [
     { name = "rioxarray" },
     { name = "s3fs" },
     { name = "titiler-core" },
+    { name = "titiler-mosaic" },
     { name = "titiler-xarray" },
     { name = "xarray" },
     { name = "zarr" },
@@ -3410,6 +3467,7 @@ requires-dist = [
     { name = "cftime" },
     { name = "fastapi" },
     { name = "fsspec" },
+    { name = "gribberish", extras = ["zarr"], specifier = ">=1.7.0" },
     { name = "h5netcdf" },
     { name = "h5py", specifier = ">=3.16.0" },
     { name = "icechunk", specifier = ">=2.0.4" },
@@ -3430,6 +3488,7 @@ requires-dist = [
     { name = "rioxarray" },
     { name = "s3fs" },
     { name = "titiler-core", specifier = ">=2.2.1,<3.0" },
+    { name = "titiler-mosaic", specifier = "==2.2.1" },
     { name = "titiler-xarray", specifier = ">=2.2.1,<3.0" },
     { name = "uvicorn", marker = "extra == 'server'" },
     { name = "xarray", specifier = ">=2025.10.1" },


### PR DESCRIPTION
## Summary

- We want to be able to support tile requests for datasets that are stored in multiple icechunk stores on distinct spatial grids. We do this type of thing for COGs using titiler.mosaic.MosaicTilerFactory
- This changes the API in a subtle way so that the `url` parameter can be provided multiple times instead of just once e.g. `url=s3://path/to/store1&url=s3://path/to/store2`. There are no other API changes that I am aware of due to switching to the MosaicTilerFactory.
  - This kind of mirrors the API described in the [Collections Selections](https://docs.ogc.org/is/20-057/20-057.html#rc_collections-selection) section of the `OGC API - Tiles - Part 1: Core spec`
<img width="1902" height="405" alt="image" src="https://github.com/user-attachments/assets/9d62ac6f-af30-473c-a23a-92cd2459ed96" />
  - Should we change this API to use `collections` instead of `url`? We don't need to decide now but I could see how these multidimensional datasets are much more like a collection than a single asset represented by a url.


## Testing

- Working locally on a sample of the NAQFC CONUS + AK Icechunk stores:
  - `url=s3://naqfc/aqmv7/o3&url=s3://naqfc/aqmv7/o3_ak&variable=ozcon`
- Working on a fresh titiler-multidim deployment **without a VPC and with no Redis cache**
  - [map link](https://k57yourj75.execute-api.us-west-2.amazonaws.com/WebMercatorQuad/map.html?url=s3://airquality-data-store-develop/naqfc/aqmv7/o3_conus&url=s3://airquality-data-store-develop/naqfc/aqmv7/o3_ak&url=s3://airquality-data-store-develop/naqfc/aqmv7/o3_hi&variable=ozcon&sel=reference_time%3Dnearest%3A%3A2025-01-01T06%3A00%3A00&sel=lead%3D1&colormap_name=viridis&rescale=0,80)
