### PR TITLE
fix: stop CDNs from caching error responses

### DIFF
--- a/src/titiler/multidim/main.py
+++ b/src/titiler/multidim/main.py
@@ -75,6 +75,7 @@ if api_settings.cors_origins:
 app.add_middleware(
     CacheControlMiddleware,
     cachecontrol=api_settings.cachecontrol,
+    cachecontrol_max_http_code=400,  # never let CDNs cache error responses
     exclude_path={r"/healthz"},
 )
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -254,3 +254,18 @@ def test_sel_nearest_netcdf(app):
     params["sel"] = "time=nearest::2020-01-06"
     response = app.get("/info", params=params)
     assert response.status_code == 200
+
+
+def test_errors_not_cacheable(app):
+    """Error responses must not carry Cache-Control, so CDNs never cache them."""
+    err = app.get("/variables")  # missing required ?url= -> 422
+    assert err.status_code == 422
+    assert "cache-control" not in err.headers
+
+    ok = app.get("/colorMaps")
+    assert ok.status_code == 200
+    assert ok.headers["cache-control"] == "public, max-age=3600"
+
+    healthz = app.get("/healthz")
+    assert healthz.status_code == 200
+    assert "cache-control" not in healthz.headers


### PR DESCRIPTION
\## Summary

I don't think we want 400 level response status codes cached. As an example, a user may get a 403 because the token or role cannot access a requested resource. Even if the auth was fixed, any user would get the same error from the CDN for the next hour.

## Testing

Ran the test suite.

## PR checks

- Standard CI runs automatically on each push.
- To run the CDK synth check, add the `run-cdk-checks` label to this PR.
- If you push more commits after that run completes, remove and re-add the label to run it again.
- To trigger a dev deployment, add the `deploy-dev` label. It smoke-tests tiles from the native MUR, virtual MUR, and virtual NLDAS Icechunk stores after deployment.
