### PR TITLE
feat: add support for iam permissions boundary on roles created by cdk

### DIFF
--- a/.github/workflows/cdk-checks.yml
+++ b/.github/workflows/cdk-checks.yml
@@ -60,6 +60,7 @@ jobs:
       TITILER_MULTIDIM_DEBUG: true
       # dummy value; synth only parses it
       TITILER_MULTIDIM_READER_ROLE_ARN: arn:aws:iam::123456789012:role/ci-dummy-reader
+      PERMISSIONS_BOUNDARY_POLICY_NAME: ci-dummy-boundary
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -3,7 +3,15 @@
 import os
 from typing import Any, Dict, Optional
 
-from aws_cdk import App, CfnOutput, Duration, Stack, Tags, aws_lambda
+from aws_cdk import (
+    App,
+    CfnOutput,
+    Duration,
+    PermissionsBoundary,
+    Stack,
+    Tags,
+    aws_lambda,
+)
 from aws_cdk import aws_apigatewayv2 as apigw
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
@@ -173,6 +181,18 @@ lambda_stack = LambdaStack(
     timeout=app_settings.timeout,
     concurrent=app_settings.max_concurrent,
     environment=app_settings.additional_env,
+lambda_stack = LambdaStack(
+    app,
+    f"{stack_settings.titiler_multidim_stack_name}-{stack_settings.stage}",
+    memory=10240,
+    timeout=app_settings.timeout,
+    concurrent=app_settings.max_concurrent,
+    environment=app_settings.additional_env,
+    permissions_boundary=(
+        PermissionsBoundary.from_name(stack_settings.permissions_boundary_policy_name)
+        if stack_settings.permissions_boundary_policy_name
+        else None
+    ),
 )
 # Tag infrastructure
 for key, value in {
@@ -183,12 +203,5 @@ for key, value in {
     if value:
         Tags.of(lambda_stack).add(key, value)
 
-if stack_settings.permissions_boundary_policy_name:
-    boundary = iam.ManagedPolicy.from_managed_policy_name(
-        lambda_stack,
-        "permissions-boundary",
-        stack_settings.permissions_boundary_policy_name,
-    )
-    iam.PermissionsBoundary.of(lambda_stack).apply(boundary)
 
 app.synth()

--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -183,5 +183,12 @@ for key, value in {
     if value:
         Tags.of(lambda_stack).add(key, value)
 
+if stack_settings.permissions_boundary_policy_name:
+    boundary = iam.ManagedPolicy.from_managed_policy_name(
+        lambda_stack,
+        "permissions-boundary",
+        stack_settings.permissions_boundary_policy_name,
+    )
+    iam.PermissionsBoundary.of(lambda_stack).apply(boundary)
 
 app.synth()

--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -173,14 +173,6 @@ class LambdaStack(Stack):
 
 app = App()
 
-
-lambda_stack = LambdaStack(
-    app,
-    f"{stack_settings.titiler_multidim_stack_name}-{stack_settings.stage}",
-    memory=10240,
-    timeout=app_settings.timeout,
-    concurrent=app_settings.max_concurrent,
-    environment=app_settings.additional_env,
 lambda_stack = LambdaStack(
     app,
     f"{stack_settings.titiler_multidim_stack_name}-{stack_settings.stage}",

--- a/src/titiler/multidim/settings.py
+++ b/src/titiler/multidim/settings.py
@@ -57,6 +57,10 @@ class StackSettings(BaseSettings):
     veda_custom_host: str | None = Field(
         None, description="Custom host URL override for API Gateway integration"
     )
+    permissions_boundary_policy_name: str | None = Field(
+        None,
+        description="Name of the IAM policy to define stack permissions boundary",
+    )
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 


### PR DESCRIPTION
## Summary

This PR adds support for IAM permissions boundary on all roles created by the CDK stack which is required for deploying to MCP (for EIC) because the permission boundary we use enforces permissions boundaries on role creation. Without this change, we're not able to successfully deploy titiler-multidim to our EIC stack https://github.com/NASA-IMPACT/veda-deploy/actions/runs/33677415786/job/100438874507

## Testing

https://github.com/NASA-IMPACT/veda-deploy/actions/runs/33690379817/job/100456303626

## PR checks

- Standard CI runs automatically on each push.
- To run the CDK synth check, add the `run-cdk-checks` label to this PR.
- If you push more commits after that run completes, remove and re-add the label to run it again.
- To trigger a dev deployment, add the `deploy-dev` label. It smoke-tests tiles from the native MUR, virtual MUR, and virtual NLDAS Icechunk stores after deployment.
